### PR TITLE
keystore: add a basic in-memory keystore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,4 +172,7 @@ Temporary Items
 # End of https://www.toptal.com/developers/gitignore/api/go,intellij,macos,linux
 
 # Ignore generated protobuf stubs
-pb/v1/service.pb.go
+*.pb.go
+
+# Ignore artifact of compiling cmd/server.go
+server

--- a/bitcoin/client.go
+++ b/bitcoin/client.go
@@ -1,0 +1,18 @@
+package bitcoin
+
+import (
+	"github.com/ledgerhq/bitcoin-keychain-svc/log"
+	"google.golang.org/grpc"
+)
+
+// NewBitcoinSvcClient creates a new CoinService client by dialing the
+// external bitcoin-svc gRPC service.
+func NewBitcoinClient() CoinServiceClient {
+	// TODO: use env vars (via config package) here.
+	conn, err := grpc.Dial("localhost:50051", grpc.WithInsecure())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return NewCoinServiceClient(conn)
+}

--- a/bitcoin/service.proto
+++ b/bitcoin/service.proto
@@ -1,0 +1,150 @@
+syntax = "proto3";
+
+package bitcoin;
+option go_package = ".;bitcoin";
+option java_package = "co.ledger.protobuf";
+
+// CoinService exposes a gRPC interface to wrap protocol-centric logic
+// related to Bitcoin.
+//
+// The current naming convention is to use the full canonical name of the
+// cryptocurrency, as opposed to the ticker.
+service CoinService {
+  // ValidateAddress checks whether an address (for the given chain parameters)
+  // is valid or not. If invalid, it also includes a string explaining the
+  // reason.
+  rpc ValidateAddress(ValidateAddressRequest) returns (ValidateAddressResponse) {}
+
+  // DeriveExtendedKey accepts a base58-encoded serialized extended key and
+  // a derivation path, and returns a child extended key derived according to
+  // BIP0032 derivation rules.
+  rpc DeriveExtendedKey(DeriveExtendedKeyRequest) returns (DeriveExtendedKeyResponse) {}
+
+  // EncodeAddress accepts a serialized public key and an encoding format,
+  // and returns the encoded address as a string.
+  //
+  // Both compressed as well as uncompressed public keys are supported,
+  // although they are internally converted to the right format before
+  // encoding the address.
+  //
+  // The method also takes in the chain parameters for using network-specific
+  // HD version bytes during encoding.
+  rpc EncodeAddress(EncodeAddressRequest) returns (EncodeAddressResponse) {}
+}
+
+// BitcoinNetwork enumerates the list of all supported Bitcoin networks. It
+// also indicates the coin for which the networks are defined, in this case,
+// Bitcoin.
+//
+// This enum type may be used by gRPC clients to differentiate protocol
+// behaviour, magic numbers, addresses, keys, etc., for one network from those
+// intended for use on another network.
+enum BitcoinNetwork {
+  BITCOIN_NETWORK_UNSPECIFIED = 0;  // Fallback value if unrecognized / unspecified
+  BITCOIN_NETWORK_MAINNET     = 1;  // Main network
+  BITCOIN_NETWORK_TESTNET3    = 2;  // Current test network (since Bitcoin Core v0.7)
+  BITCOIN_NETWORK_REGTEST     = 3;  // Regression test network
+}
+
+// ChainParams defines all the configuration required to uniquely identify a
+// coin, along with its network.
+//
+// It can accommodate Bitcoin forks in future in a backwards compatible way.
+//
+// Currently, it only includes network information, although more fields may
+// be included in future.
+message ChainParams {
+  oneof network {
+    BitcoinNetwork bitcoin_network = 1;
+  }
+}
+
+// ValidateAddressRequest defines the input request passed to ValidateAddress
+// RPC method.
+message ValidateAddressRequest {
+  // Address to be validated.
+  string address = 1;
+
+  // Chain params to identify the coin and network for which the address
+  // must be validated.
+  ChainParams chain_params = 2;
+}
+
+// ValidateAddressResponse wraps the output response of ValidateAddress RPC.
+message ValidateAddressResponse {
+  // Address in normalized form, if valid; original address otherwise.
+  string address = 1;
+
+  // Whether the input address is valid or not.
+  bool is_valid = 2;
+
+  // Human-readable reason for the address being invalid. Use ONLY if is_valid
+  // is false.
+  string invalid_reason = 3;
+}
+
+// DeriveExtendedKeyRequest defines the input request passed to DeriveExtendedKey
+// RPC method.
+message DeriveExtendedKeyRequest {
+  // Extended key serialized as a base58-encoded string.
+  string extended_key = 1;
+
+  // Derivation path relative to HD depth of extended_key field.
+  //
+  // The derivation path is represented by an array of child indexes. Each
+  // child index in the path must be between 0 and 2^31-1, i.e., they should
+  // not be hardened.
+  repeated uint32 derivation = 2;
+}
+
+// DeriveExtendedKeyResponse wraps the output response of DeriveExtendedKey RPC.
+message DeriveExtendedKeyResponse {
+  // Extended key serialized as a base58-encoded string.
+  string extended_key = 1;
+
+  // Serialized compressed public key associated with the extended key derived
+  // at the specified derivation path.
+  //
+  // This field is 33 bytes long.
+  bytes public_key = 2;
+
+  // Serialized chain code associated with the extended key derived at the
+  // specified derivation path.
+  //
+  // This field is 32 bytes long.
+  bytes chain_code = 3;
+}
+
+// AddressEncoding enumerates the list of all supported encoding formats, for
+// serializing addresses.
+//
+// It is agnostic of the chain parameters.
+enum AddressEncoding {
+  ADDRESS_ENCODING_UNSPECIFIED  = 0;  // Fallback value if unrecognized / unspecified
+  ADDRESS_ENCODING_P2PKH        = 1;  // Pay-to-PubKey-Hash
+  ADDRESS_ENCODING_P2SH_P2WPKH  = 2;  // Pay-to-Witness-PubKey-Hash in Pay-to-Script-Hash
+  ADDRESS_ENCODING_P2WPKH       = 3;  // Pay-to-Witness-PubKey-Hash
+}
+
+// EncodeAddressRequest defines the input request passed to EncodeAddress
+// RPC method.
+message EncodeAddressRequest {
+  // Serialized public key from which the address must be encoded.
+  //
+  // This field must be 33 bytes long, for compressed keys, or 65 bytes long
+  // for uncompressed keys.
+  bytes public_key = 1;
+
+  // Address encoding scheme to use.
+  AddressEncoding encoding = 3;
+
+  // Chain params to identify the coin and network to be used for encoding the
+  // address.
+  ChainParams chain_params = 4;
+}
+
+// EncodeAddressResponse wraps the output response of EncodeAddress RPC.
+message EncodeAddressResponse {
+  // Address serialized from the given public key, using the specified encoding.
+  string address = 2;
+}

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,13 @@ module github.com/ledgerhq/bitcoin-keychain-svc
 go 1.14
 
 require (
+	github.com/golang/protobuf v1.4.1
 	github.com/ledgerhq/bitcoin-keychain-svc/pb v0.1.0
 	github.com/magefile/mage v1.10.0
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/viper v1.3.2
 	google.golang.org/genproto v0.0.0-20200715011427-11fb19a81f2c // indirect
-	google.golang.org/grpc v1.30.0 // indirect
+	google.golang.org/grpc v1.30.0
 	google.golang.org/protobuf v1.25.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang/protobuf v1.4.1
 	github.com/ledgerhq/bitcoin-keychain-svc/pb v0.1.0
 	github.com/magefile/mage v1.10.0
+	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/viper v1.3.2
 	google.golang.org/genproto v0.0.0-20200715011427-11fb19a81f2c // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/grpc/keychain.go
+++ b/grpc/keychain.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+
 	"github.com/ledgerhq/bitcoin-keychain-svc/pb/v1"
 	"github.com/ledgerhq/bitcoin-keychain-svc/pkg/keystore"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -13,7 +14,7 @@ type controller struct {
 
 func (c controller) CreateKeychain(
 	ctx context.Context, request *pb.CreateKeychainRequest,
-) (*pb.KeychainInfo, error) {
+) (*pb.GetKeychainInfoResponse, error) {
 	panic("implement me")
 }
 
@@ -25,10 +26,12 @@ func (c controller) DeleteKeychain(
 
 func (c controller) GetKeychainInfo(
 	ctx context.Context, request *pb.GetKeychainInfoRequest,
-) (*pb.KeychainInfo, error) {
+) (*pb.GetKeychainInfoResponse, error) {
 	panic("implement me")
 }
 
+// NewKeychainController returns a new instance of a controller struct that
+// implements the pb.KeychainServiceServer interface.
 func NewKeychainController() *controller {
 	return &controller{
 		store: keystore.NewInMemoryKeystore(),

--- a/pkg/keystore/descriptor.go
+++ b/pkg/keystore/descriptor.go
@@ -1,1 +1,53 @@
 package keystore
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+// DescriptorTokens models the result of parsing an output descriptor.
+type DescriptorTokens struct {
+	XPub   string
+	Scheme Scheme
+}
+
+// ParseDescriptor is a very basic tokenizer of output descriptor strings.
+//
+// References:
+//   https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
+//   https://github.com/bitcoin-core/HWI/blob/master/hwilib/descriptor.py
+//   https://github.com/bitcoin/bitcoin/blob/master/src/script/descriptor.cpp
+//
+// TODO: Upstream this to btcsuite/btcutil, and access it through bitcoin-svc.
+func ParseDescriptor(descriptor string) (DescriptorTokens, error) {
+	var scheme Scheme
+
+	if strings.HasPrefix(descriptor, "sh(wpkh(") {
+		scheme = BIP49
+	} else if strings.HasPrefix(descriptor, "wpkh(") {
+		scheme = BIP84
+	} else if strings.HasPrefix(descriptor, "pkh(") {
+		scheme = BIP44
+	} else {
+		return DescriptorTokens{}, errors.New("unrecognized scheme")
+	}
+
+	// Match the base key using regex, and ignore everything else.
+	// FIXME: make the regex match more robust.
+	r := regexp.MustCompile(`.*\((?:\[.*])?([\w+]*).*\).*`)
+	groups := r.FindStringSubmatch(descriptor)
+	if len(groups) != 2 {
+		return DescriptorTokens{}, errors.New("invalid descriptor")
+	}
+
+	xpub := groups[1]
+	if xpub == "" {
+		return DescriptorTokens{}, errors.New("invalid descriptor")
+	}
+
+	return DescriptorTokens{
+		XPub:   xpub,
+		Scheme: scheme,
+	}, nil
+}

--- a/pkg/keystore/descriptor.go
+++ b/pkg/keystore/descriptor.go
@@ -12,6 +12,10 @@ type DescriptorTokens struct {
 	Scheme Scheme
 }
 
+// Match the base key using regex, and ignore everything else.
+// FIXME: make the regex match more robust.
+var descriptorRegex = regexp.MustCompile(`.*\((?:\[.*])?([\w+]*).*\).*`)
+
 // ParseDescriptor is a very basic tokenizer of output descriptor strings.
 //
 // References:
@@ -34,10 +38,7 @@ func ParseDescriptor(descriptor string) (DescriptorTokens, error) {
 			"failed to parse descriptor %v", descriptor)
 	}
 
-	// Match the base key using regex, and ignore everything else.
-	// FIXME: make the regex match more robust.
-	r := regexp.MustCompile(`.*\((?:\[.*])?([\w+]*).*\).*`)
-	groups := r.FindStringSubmatch(descriptor)
+	groups := descriptorRegex.FindStringSubmatch(descriptor)
 	if len(groups) != 2 {
 		return DescriptorTokens{}, errors.Wrapf(
 			ErrInvalidDescriptor, "failed to parse descriptor %v", descriptor)

--- a/pkg/keystore/descriptor.go
+++ b/pkg/keystore/descriptor.go
@@ -1,7 +1,7 @@
 package keystore
 
 import (
-	"errors"
+	"github.com/pkg/errors"
 	"regexp"
 	"strings"
 )
@@ -30,7 +30,8 @@ func ParseDescriptor(descriptor string) (DescriptorTokens, error) {
 	} else if strings.HasPrefix(descriptor, "pkh(") {
 		scheme = BIP44
 	} else {
-		return DescriptorTokens{}, errors.New("unrecognized scheme")
+		return DescriptorTokens{}, errors.Wrapf(ErrUnrecognizedScheme,
+			"failed to parse descriptor %v", descriptor)
 	}
 
 	// Match the base key using regex, and ignore everything else.
@@ -38,12 +39,14 @@ func ParseDescriptor(descriptor string) (DescriptorTokens, error) {
 	r := regexp.MustCompile(`.*\((?:\[.*])?([\w+]*).*\).*`)
 	groups := r.FindStringSubmatch(descriptor)
 	if len(groups) != 2 {
-		return DescriptorTokens{}, errors.New("invalid descriptor")
+		return DescriptorTokens{}, errors.Wrapf(
+			ErrInvalidDescriptor, "failed to parse descriptor %v", descriptor)
 	}
 
 	xpub := groups[1]
 	if xpub == "" {
-		return DescriptorTokens{}, errors.New("invalid descriptor")
+		return DescriptorTokens{}, errors.Wrapf(ErrInvalidDescriptor,
+			"empty xpub in descriptor %v", descriptor)
 	}
 
 	return DescriptorTokens{

--- a/pkg/keystore/descriptor_test.go
+++ b/pkg/keystore/descriptor_test.go
@@ -1,0 +1,81 @@
+package keystore
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseDescriptor(t *testing.T) {
+	tests := []struct {
+		name       string
+		descriptor string
+		want       DescriptorTokens
+		err        string
+	}{
+		{
+			name:       "legacy",
+			descriptor: "pkh(deadbeef)",
+			want: DescriptorTokens{
+				XPub:   "deadbeef",
+				Scheme: "BIP44",
+			},
+		},
+		{
+			name:       "wrapped segwit",
+			descriptor: "sh(wpkh(deadbeef))",
+			want: DescriptorTokens{
+				XPub:   "deadbeef",
+				Scheme: "BIP49",
+			},
+		},
+		{
+			name:       "native segwit",
+			descriptor: "wpkh(deadbeef)",
+			want: DescriptorTokens{
+				XPub:   "deadbeef",
+				Scheme: "BIP84",
+			},
+		},
+		{
+			name:       "verbose wrapped segwit",
+			descriptor: "sh(wpkh([d34db33f/44'/0'/0']deadbeef/1/*))",
+			want: DescriptorTokens{
+				XPub:   "deadbeef",
+				Scheme: "BIP49",
+			},
+		},
+		{
+			name:       "invalid scheme",
+			descriptor: "abcd(deadbeef)",
+			err:        "unrecognized scheme",
+		},
+		{
+			name:       "invalid descriptor",
+			descriptor: "wpkh(deadbeef",
+			err:        "invalid descriptor",
+		},
+		{
+			name:       "empty descriptor",
+			descriptor: "wpkh()",
+			err:        "invalid descriptor",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseDescriptor(tt.descriptor)
+			if err != nil {
+				if tt.err == "" {
+					t.Fatalf("ParseDescriptor: unexpected error - %v", err)
+				}
+
+				if tt.err != err.Error() {
+					t.Fatalf("ParseDescriptor: expected error '%v', got '%v'", tt.err, err)
+				}
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseDescriptor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/keystore/errors.go
+++ b/pkg/keystore/errors.go
@@ -1,0 +1,17 @@
+package keystore
+
+import "github.com/pkg/errors"
+
+var (
+	// ErrInvalidDescriptor indicates that a descriptor string does not
+	// have the expected structure/format.
+	ErrInvalidDescriptor = errors.New("invalid descriptor")
+
+	// ErrUnrecognizedScheme indicates that the parsed scheme of a descriptor
+	// is invalid or missing.
+	ErrUnrecognizedScheme = errors.New("unrecognized scheme")
+
+	// ErrDescriptorNotFound indicates an attempt to get a descriptor from a
+	// keystore that has not been registered.
+	ErrDescriptorNotFound = errors.New("descriptor not found")
+)

--- a/pkg/keystore/memory.go
+++ b/pkg/keystore/memory.go
@@ -1,17 +1,36 @@
 package keystore
 
-import "errors"
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+
+	"github.com/ledgerhq/bitcoin-keychain-svc/bitcoin"
+)
 
 // InMemoryKeystore implements the Keystore interface where the storage
 // is an in-memory map. Useful for unit-tests.
+//
+// It also includes a client to communicate with a bitcoin-svc gRPC server
+// for protocol-level operations.
 type InMemoryKeystore struct {
-	db KeystoreSchema
+	db     Schema
+	client bitcoin.CoinServiceClient
 }
 
+// NewInMemoryKeystore returns an instance of InMemoryKeystore which implements
+// the Keystore interface.
 func NewInMemoryKeystore() Keystore {
-	return &InMemoryKeystore{}
+	return &InMemoryKeystore{
+		db:     Schema{},
+		client: bitcoin.NewBitcoinClient(),
+	}
 }
 
+// Get returns a previously stored keychain information based on the provided
+// descriptor string.
+//
+// Returns an error if the descriptor is missing in the keystore.
 func (s *InMemoryKeystore) Get(descriptor string) (KeychainInfo, error) {
 	document, ok := s.db[descriptor]
 	if !ok {
@@ -21,18 +40,59 @@ func (s *InMemoryKeystore) Get(descriptor string) (KeychainInfo, error) {
 	return document.Main, nil
 }
 
+// Create parses a descriptor string and populars the in-memory keystore with
+// the corresponding keychain information.
+//
+// Only initial state is populated, so no addresses will be inserted into the
+// keystore by this method.
 func (s *InMemoryKeystore) Create(descriptor string) (KeychainInfo, error) {
-	return KeychainInfo{
+	tokens, err := ParseDescriptor(descriptor)
+	if err != nil {
+		return KeychainInfo{}, err
+	}
+
+	ckdFunc := func(childIndex uint32) (string, string, error) {
+		child, err := s.client.DeriveExtendedKey(
+			context.Background(), &bitcoin.DeriveExtendedKeyRequest{
+				ExtendedKey: tokens.XPub,
+				Derivation:  []uint32{childIndex},
+			})
+		if err != nil {
+			return "", "", nil
+		}
+
+		return hex.EncodeToString(child.PublicKey), hex.EncodeToString(child.ChainCode), nil
+	}
+
+	externalPublicKey, externalChainCode, err := ckdFunc(0)
+	if err != nil {
+		return KeychainInfo{}, err
+	}
+
+	internalPublicKey, internalChainCode, err := ckdFunc(1)
+	if err != nil {
+		return KeychainInfo{}, err
+	}
+
+	keychainInfo := KeychainInfo{
 		Descriptor:              descriptor,
-		XPub:                    "",
-		SLIP32ExtendedPublicKey: "",
-		ExternalPublicKey:       "",
-		ExternalChainCode:       "",
+		XPub:                    tokens.XPub,
+		SLIP32ExtendedPublicKey: tokens.XPub, // TODO: Convert XPub to SLIP-0132 form
+		ExternalPublicKey:       externalPublicKey,
+		ExternalChainCode:       externalChainCode,
 		MaxExternalIndex:        0,
-		InternalPublicKey:       "",
-		InternalChainCode:       "",
+		InternalPublicKey:       internalPublicKey,
+		InternalChainCode:       internalChainCode,
 		MaxInternalIndex:        0,
-		LookaheadSize:           0,
-		Scheme:                  "",
-	}, nil
+		LookaheadSize:           20,
+		Scheme:                  tokens.Scheme,
+	}
+
+	s.db[descriptor] = Meta{
+		Main:        keychainInfo,
+		Derivations: nil,
+		Addresses:   nil,
+	}
+
+	return keychainInfo, nil
 }

--- a/pkg/keystore/memory_test.go
+++ b/pkg/keystore/memory_test.go
@@ -1,0 +1,141 @@
+package keystore
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/ledgerhq/bitcoin-keychain-svc/bitcoin"
+	"google.golang.org/grpc"
+)
+
+type mockBitcoinClient struct{}
+
+func (c mockBitcoinClient) ValidateAddress(
+	ctx context.Context,
+	in *bitcoin.ValidateAddressRequest,
+	opts ...grpc.CallOption,
+) (*bitcoin.ValidateAddressResponse, error) {
+	return &bitcoin.ValidateAddressResponse{
+		Address: in.Address,
+		IsValid: true,
+	}, nil
+}
+
+func (c mockBitcoinClient) DeriveExtendedKey(
+	ctx context.Context,
+	in *bitcoin.DeriveExtendedKeyRequest,
+	opts ...grpc.CallOption,
+) (*bitcoin.DeriveExtendedKeyResponse, error) {
+	extendedKey := in.ExtendedKey
+	publicKey := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	chainCode := []byte{0xCA, 0xFE, 0xBA, 0xBE}
+
+	for _, index := range in.Derivation {
+		extendedKey += "->" + strconv.Itoa(int(index))
+		publicKey = append(publicKey, byte(index))
+		chainCode = append(chainCode, byte(index))
+	}
+
+	return &bitcoin.DeriveExtendedKeyResponse{
+		ExtendedKey: extendedKey,
+		PublicKey:   publicKey,
+		ChainCode:   chainCode,
+	}, nil
+}
+
+func (c mockBitcoinClient) EncodeAddress(
+	ctx context.Context,
+	in *bitcoin.EncodeAddressRequest,
+	opts ...grpc.CallOption,
+) (*bitcoin.EncodeAddressResponse, error) {
+	return &bitcoin.EncodeAddressResponse{
+		Address: "deadbeef",
+	}, nil
+}
+
+func NewMockInMemoryKeystore() Keystore {
+	return &InMemoryKeystore{
+		db:     Schema{},
+		client: mockBitcoinClient{},
+	}
+}
+
+func TestInMemoryKeystore_GetCreate(t *testing.T) {
+	tests := []struct {
+		name       string
+		descriptor string
+		want       KeychainInfo
+		wantErr    error
+	}{
+		{
+			name:       "invalid descriptor",
+			descriptor: "bad xpub",
+			wantErr:    errors.New("unrecognized scheme"),
+		},
+		{
+			name:       "native segwit",
+			descriptor: "wpkh(xpub1111)",
+			want: KeychainInfo{
+				Descriptor:              "wpkh(xpub1111)",
+				XPub:                    "xpub1111",
+				SLIP32ExtendedPublicKey: "xpub1111",
+				ExternalPublicKey:       "deadbeef00",
+				ExternalChainCode:       "cafebabe00",
+				MaxExternalIndex:        0,
+				InternalPublicKey:       "deadbeef01",
+				InternalChainCode:       "cafebabe01",
+				MaxInternalIndex:        0,
+				LookaheadSize:           20,
+				Scheme:                  "BIP84",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keystore := NewMockInMemoryKeystore()
+
+			got, err := keystore.Create(tt.descriptor)
+			if err != nil && tt.wantErr == nil {
+				t.Fatalf("Create() unexpected error: %v", err)
+			}
+
+			if err == nil && tt.wantErr != nil {
+				t.Fatalf("Create() got no error, want '%v'",
+					tt.wantErr)
+			}
+
+			if err != nil && tt.wantErr.Error() != err.Error() {
+				t.Fatalf("Create() got error '%v', want '%v'",
+					err, tt.wantErr)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Create() got = '%v', want = '%v'",
+					got, tt.want)
+			}
+
+			gotDB, dbErr := keystore.Get(tt.descriptor)
+			if dbErr != nil && err == nil {
+				t.Fatalf("Get() unexpected error: %v", dbErr)
+			}
+
+			if dbErr == nil && err != nil {
+				t.Fatalf("Get() got no error, want '%v'",
+					errors.New("does not exist"))
+			}
+
+			if dbErr != nil && dbErr.Error() != errors.New("does not exist").Error() {
+				t.Fatalf("Get() got error '%v', want '%v'",
+					dbErr, errors.New("does not exist"))
+			}
+
+			if !reflect.DeepEqual(gotDB, tt.want) {
+				t.Fatalf("Get() got = '%v', want = '%v'",
+					gotDB, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/keystore/memory_test.go
+++ b/pkg/keystore/memory_test.go
@@ -2,7 +2,7 @@ package keystore
 
 import (
 	"context"
-	"errors"
+	"github.com/pkg/errors"
 	"reflect"
 	"strconv"
 	"testing"
@@ -73,7 +73,7 @@ func TestInMemoryKeystore_GetCreate(t *testing.T) {
 		{
 			name:       "invalid descriptor",
 			descriptor: "bad xpub",
-			wantErr:    errors.New("unrecognized scheme"),
+			wantErr:    ErrUnrecognizedScheme,
 		},
 		{
 			name:       "native segwit",
@@ -107,7 +107,7 @@ func TestInMemoryKeystore_GetCreate(t *testing.T) {
 					tt.wantErr)
 			}
 
-			if err != nil && tt.wantErr.Error() != err.Error() {
+			if err != nil && errors.Cause(err) != tt.wantErr {
 				t.Fatalf("Create() got error '%v', want '%v'",
 					err, tt.wantErr)
 			}
@@ -124,12 +124,12 @@ func TestInMemoryKeystore_GetCreate(t *testing.T) {
 
 			if dbErr == nil && err != nil {
 				t.Fatalf("Get() got no error, want '%v'",
-					errors.New("does not exist"))
+					ErrDescriptorNotFound)
 			}
 
-			if dbErr != nil && dbErr.Error() != errors.New("does not exist").Error() {
+			if dbErr != nil && errors.Cause(dbErr) != ErrDescriptorNotFound {
 				t.Fatalf("Get() got error '%v', want '%v'",
-					dbErr, errors.New("does not exist"))
+					dbErr, ErrDescriptorNotFound)
 			}
 
 			if !reflect.DeepEqual(gotDB, tt.want) {

--- a/pkg/keystore/store.go
+++ b/pkg/keystore/store.go
@@ -1,7 +1,12 @@
 package keystore
 
+// Keystore is an interface that all keychain storage backends must implement.
+// Currently, there are two Keystore implementations available:
+//   InMemoryKeystore: useful for unit-tests
+//   RedisKeystore:    TBA
 type Keystore interface {
-	Get(string) (KeychainInfo, error)
+	Get(descriptor string) (KeychainInfo, error)
+	Create(descriptor string) (KeychainInfo, error)
 }
 
 // Scheme defines the scheme on which a keychain entry is based.
@@ -18,6 +23,11 @@ const (
 	BIP84 Scheme = "BIP84"
 )
 
+// KeychainInfo models the global information related to an account registered
+// in the keystore.
+//
+// Rather than using the associated gRPC message struct, it is defined here
+// independently to avoid having gRPC dependency in this package.
 type KeychainInfo struct {
 	Descriptor              string `json:"descriptor"`
 	XPub                    string `json:"xpub"`                       // Extended public key serialized with standard HD version bytes
@@ -37,9 +47,12 @@ type derivationToPublicKeyMap map[string]struct {
 	Used      bool   `json:"used"`       // Whether any txn history at derivation
 }
 
-// KeystoreSchema is a map containing keychain data corresponding to an
-// account descriptor.
-type KeystoreSchema map[string]struct {
+// Schema is a map between account descriptors and account information.
+type Schema map[string]Meta
+
+// Meta is a struct containing account details corresponding to a descriptor,
+// such as derivations, addresses, etc.
+type Meta struct {
 	Main        KeychainInfo             `json:"main"`
 	Derivations derivationToPublicKeyMap `json:"derivations"`
 	Addresses   map[string][2]uint32     `json:"addresses"` // derivation path at HD tree depth 5


### PR DESCRIPTION
### What is this?

|JIRA| [`BACK-757`](https://ledgerhq.atlassian.net/browse/BACK-757) | [`BACK-758`](https://ledgerhq.atlassian.net/browse/BACK-758)
-|-|-

This PR adds an implementation of the `Keystore` interface called `InMemoryKeystore`. It also includes a simple parser to extract relevant information from an output descriptor string, which is also used as a **Keychain URI**.

### Cute picture of animal

![](https://media1.tenor.com/images/42716485dccda852bd18066885fa2e36/tenor.gif?itemid=7316260)