### PR TITLE
Setup CI with GitHub Actions and fix lint errors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,64 @@
+name: Build and Test
+on: [push, pull_request]
+jobs:
+  build:
+    name: Go CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Install mage
+        run: "pushd /tmp; git clone https://github.com/magefile/mage; pushd mage; go run bootstrap.go; popd; popd"
+
+      - name: Install golangci-lint
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.28.0"
+
+      - name: Install Protobuf compiler
+        uses: arduino/setup-protoc@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Protobuf Go plugin
+        run: |
+          go get github.com/golang/protobuf/protoc-gen-go
+
+      - name: Install Buf compiler
+        env:
+          BUF_VERSION: "0.20.1"
+          BUF: "/var/tmp/buf"
+        run: |
+          UNAME_OS=$(uname -s)
+          UNAME_ARCH=$(uname -m)
+
+          wget "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-${UNAME_OS}-${UNAME_ARCH}" -O ${BUF}
+          chmod +x ${BUF}
+
+      - name: Run Buf checks
+        env:
+          BUF: "/var/tmp/buf"
+        run: mage -v buf
+
+      - name: Build
+        run: |
+          mage -v build
+
+      - name: Run golangci-lint
+        run: |
+          mage -v lint
+
+      - name: Test (with -race flag)
+        run: mage -v testracecover
+
+      - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.txt
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,12 @@
+lint:
+  use:
+    - DEFAULT
+  except:
+    - RPC_REQUEST_STANDARD_NAME
+    - RPC_RESPONSE_STANDARD_NAME
+    - RPC_REQUEST_RESPONSE_UNIQUE
+  ignore:
+    - bitcoin
+  rpc_allow_google_protobuf_empty_requests: true
+  rpc_allow_google_protobuf_empty_responses: true
+

--- a/grpc/adapters.go
+++ b/grpc/adapters.go
@@ -7,20 +7,20 @@ import (
 
 // KeychainInfo is an adapter function to convert a keystore.KeychainInfo
 // instance to the corresponding protobuf message format.
-func KeychainInfo(value keystore.KeychainInfo) *pb.GetKeychainInfoResponse {
-	var scheme pb.GetKeychainInfoResponse_Scheme
+func KeychainInfo(value keystore.KeychainInfo) *pb.KeychainInfo {
+	var scheme pb.KeychainInfo_Scheme
 	switch value.Scheme {
 	case keystore.BIP44:
-		scheme = pb.GetKeychainInfoResponse_SCHEME_BIP44
+		scheme = pb.KeychainInfo_SCHEME_BIP44
 	case keystore.BIP49:
-		scheme = pb.GetKeychainInfoResponse_SCHEME_BIP49
+		scheme = pb.KeychainInfo_SCHEME_BIP49
 	case keystore.BIP84:
-		scheme = pb.GetKeychainInfoResponse_SCHEME_BIP84
+		scheme = pb.KeychainInfo_SCHEME_BIP84
 	default:
-		scheme = pb.GetKeychainInfoResponse_SCHEME_UNSPECIFIED
+		scheme = pb.KeychainInfo_SCHEME_UNSPECIFIED
 	}
 
-	return &pb.GetKeychainInfoResponse{
+	return &pb.KeychainInfo{
 		AccountDescriptor:       value.Descriptor,
 		Xpub:                    value.XPub,
 		Slip32ExtendedPublicKey: value.SLIP32ExtendedPublicKey,

--- a/grpc/adapters.go
+++ b/grpc/adapters.go
@@ -9,6 +9,7 @@ import (
 // instance to the corresponding protobuf message format.
 func KeychainInfo(value keystore.KeychainInfo) *pb.KeychainInfo {
 	var scheme pb.KeychainInfo_Scheme
+
 	switch value.Scheme {
 	case keystore.BIP44:
 		scheme = pb.KeychainInfo_SCHEME_BIP44

--- a/grpc/adapters.go
+++ b/grpc/adapters.go
@@ -1,0 +1,36 @@
+package grpc
+
+import (
+	"github.com/ledgerhq/bitcoin-keychain-svc/pb/v1"
+	"github.com/ledgerhq/bitcoin-keychain-svc/pkg/keystore"
+)
+
+// KeychainInfo is an adapter function to convert a keystore.KeychainInfo
+// instance to the corresponding protobuf message format.
+func KeychainInfo(value keystore.KeychainInfo) *pb.GetKeychainInfoResponse {
+	var scheme pb.GetKeychainInfoResponse_Scheme
+	switch value.Scheme {
+	case keystore.BIP44:
+		scheme = pb.GetKeychainInfoResponse_SCHEME_BIP44
+	case keystore.BIP49:
+		scheme = pb.GetKeychainInfoResponse_SCHEME_BIP49
+	case keystore.BIP84:
+		scheme = pb.GetKeychainInfoResponse_SCHEME_BIP84
+	default:
+		scheme = pb.GetKeychainInfoResponse_SCHEME_UNSPECIFIED
+	}
+
+	return &pb.GetKeychainInfoResponse{
+		AccountDescriptor:       value.Descriptor,
+		Xpub:                    value.XPub,
+		Slip32ExtendedPublicKey: value.SLIP32ExtendedPublicKey,
+		ExternalPublicKey:       value.ExternalPublicKey,
+		ExternalChainCode:       value.ExternalChainCode,
+		MaxExternalIndex:        value.MaxExternalIndex,
+		InternalPublicKey:       value.InternalPublicKey,
+		InternalChainCode:       value.ExternalChainCode,
+		MaxInternalIndex:        value.MaxInternalIndex,
+		LookaheadSize:           value.LookaheadSize,
+		Scheme:                  scheme,
+	}
+}

--- a/grpc/keychain.go
+++ b/grpc/keychain.go
@@ -17,7 +17,12 @@ type Controller struct {
 func (c Controller) CreateKeychain(
 	ctx context.Context, request *pb.CreateKeychainRequest,
 ) (*pb.GetKeychainInfoResponse, error) {
-	panic("implement me")
+	r, err := c.store.Create(request.AccountDescriptor)
+	if err != nil {
+		return nil, err
+	}
+
+	return KeychainInfo(r), nil
 }
 
 func (c Controller) DeleteKeychain(
@@ -29,7 +34,12 @@ func (c Controller) DeleteKeychain(
 func (c Controller) GetKeychainInfo(
 	ctx context.Context, request *pb.GetKeychainInfoRequest,
 ) (*pb.GetKeychainInfoResponse, error) {
-	panic("implement me")
+	r, err := c.store.Get(request.AccountDescriptor)
+	if err != nil {
+		return nil, err
+	}
+
+	return KeychainInfo(r), nil
 }
 
 // NewKeychainController returns a new instance of a Controller struct that

--- a/grpc/keychain.go
+++ b/grpc/keychain.go
@@ -16,7 +16,7 @@ type Controller struct {
 
 func (c Controller) CreateKeychain(
 	ctx context.Context, request *pb.CreateKeychainRequest,
-) (*pb.GetKeychainInfoResponse, error) {
+) (*pb.KeychainInfo, error) {
 	r, err := c.store.Create(request.AccountDescriptor)
 	if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func (c Controller) DeleteKeychain(
 
 func (c Controller) GetKeychainInfo(
 	ctx context.Context, request *pb.GetKeychainInfoRequest,
-) (*pb.GetKeychainInfoResponse, error) {
+) (*pb.KeychainInfo, error) {
 	r, err := c.store.Get(request.AccountDescriptor)
 	if err != nil {
 		return nil, err

--- a/grpc/keychain.go
+++ b/grpc/keychain.go
@@ -8,32 +8,34 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type controller struct {
+// Controller is a type that implements the pb.KeychainServiceServer
+// interface.
+type Controller struct {
 	store keystore.Keystore
 }
 
-func (c controller) CreateKeychain(
+func (c Controller) CreateKeychain(
 	ctx context.Context, request *pb.CreateKeychainRequest,
 ) (*pb.GetKeychainInfoResponse, error) {
 	panic("implement me")
 }
 
-func (c controller) DeleteKeychain(
+func (c Controller) DeleteKeychain(
 	ctx context.Context, request *pb.DeleteKeychainRequest,
 ) (*emptypb.Empty, error) {
 	panic("implement me")
 }
 
-func (c controller) GetKeychainInfo(
+func (c Controller) GetKeychainInfo(
 	ctx context.Context, request *pb.GetKeychainInfoRequest,
 ) (*pb.GetKeychainInfoResponse, error) {
 	panic("implement me")
 }
 
-// NewKeychainController returns a new instance of a controller struct that
+// NewKeychainController returns a new instance of a Controller struct that
 // implements the pb.KeychainServiceServer interface.
-func NewKeychainController() *controller {
-	return &controller{
+func NewKeychainController() *Controller {
+	return &Controller{
 		store: keystore.NewInMemoryKeystore(),
 	}
 }

--- a/magefile.go
+++ b/magefile.go
@@ -48,7 +48,7 @@ func Proto() error {
 	runner := func(proto string, dir string) error {
 		return sh.Run(protoc,
 			fmt.Sprintf("--go_out=%s:%s", protoPlugins, dir), // protoc flags
-			fmt.Sprintf("%s/%s", dir, proto)) // input .proto
+			fmt.Sprintf("%s/%s", dir, proto))                 // input .proto
 	}
 
 	if err := runner(protoFile, protoDir); err != nil {

--- a/magefile.go
+++ b/magefile.go
@@ -48,7 +48,7 @@ func Proto() error {
 	runner := func(proto string, dir string) error {
 		return sh.Run(protoc,
 			fmt.Sprintf("--go_out=%s:%s", protoPlugins, dir), // protoc flags
-			fmt.Sprintf("%s/%s", dir, proto)) // input .proto
+			fmt.Sprintf("%s/%s", dir, proto))                 // input .proto
 	}
 
 	if err := runner(protoFile, protoDir); err != nil {
@@ -104,10 +104,21 @@ func TestRaceCover() error {
 func Lint() error {
 	linterArgs := []string{
 		"run",
-		"--disable-all",
-		"--enable=govet",
-		"--enable=gofmt",
-		"--enable=gosec",
+		"-E=golint",
+		"-E=gosec",
+		"-E=interfacer",
+		"-E=unconvert",
+		"-E=dupl",
+		"-E=goconst",
+		"-E=gofmt",
+		"-E=goimports",
+		"-E=maligned",
+		"-E=depguard",
+		"-E=misspell",
+		"-E=prealloc",
+		"-E=whitespace",
+		"-E=wsl",
+		"-E=gocritic",
 	}
 
 	if err := sh.Run("golangci-lint", linterArgs...); err != nil {

--- a/magefile.go
+++ b/magefile.go
@@ -48,7 +48,7 @@ func Proto() error {
 	runner := func(proto string, dir string) error {
 		return sh.Run(protoc,
 			fmt.Sprintf("--go_out=%s:%s", protoPlugins, dir), // protoc flags
-			fmt.Sprintf("%s/%s", dir, proto))                 // input .proto
+			fmt.Sprintf("%s/%s", dir, proto)) // input .proto
 	}
 
 	if err := runner(protoFile, protoDir); err != nil {
@@ -64,10 +64,8 @@ func Buf() error {
 		return err
 	}
 
-	protoPath := fmt.Sprintf("%s/%s", protoDir, protoFile)
-
 	// Run Buf lint checks on the protobuf file.
-	if err := sh.Run(buf, "check", "lint", "--file", protoPath); err != nil {
+	if err := sh.Run(buf, "check", "lint"); err != nil {
 		return err
 	}
 

--- a/pb/v1/service.proto
+++ b/pb/v1/service.proto
@@ -8,13 +8,13 @@ import "google/protobuf/empty.proto";
 
 service KeychainService {
   // Create a new keychain by descriptor.
-  rpc CreateKeychain(CreateKeychainRequest) returns (GetKeychainInfoResponse) {}
+  rpc CreateKeychain(CreateKeychainRequest) returns (KeychainInfo) {}
 
   // Delete a keychain by descriptor.
   rpc DeleteKeychain(DeleteKeychainRequest) returns (google.protobuf.Empty) {}
 
   // Get keychain metadata.
-  rpc GetKeychainInfo(GetKeychainInfoRequest) returns (GetKeychainInfoResponse) {}
+  rpc GetKeychainInfo(GetKeychainInfoRequest) returns (KeychainInfo) {}
 }
 
 message CreateKeychainRequest {
@@ -30,7 +30,7 @@ message GetKeychainInfoRequest {
   string account_descriptor = 1;
 }
 
-message GetKeychainInfoResponse {
+message KeychainInfo {
   // Account descriptor of the keychain, at HD depth 3. MUST include the key
   // origin information.
   // Ref: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/pkg/keystore/descriptor.go
+++ b/pkg/keystore/descriptor.go
@@ -1,9 +1,10 @@
 package keystore
 
 import (
-	"github.com/pkg/errors"
 	"regexp"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // DescriptorTokens models the result of parsing an output descriptor.
@@ -27,13 +28,14 @@ var descriptorRegex = regexp.MustCompile(`.*\((?:\[.*])?([\w+]*).*\).*`)
 func ParseDescriptor(descriptor string) (DescriptorTokens, error) {
 	var scheme Scheme
 
-	if strings.HasPrefix(descriptor, "sh(wpkh(") {
+	switch {
+	case strings.HasPrefix(descriptor, "sh(wpkh("):
 		scheme = BIP49
-	} else if strings.HasPrefix(descriptor, "wpkh(") {
+	case strings.HasPrefix(descriptor, "wpkh("):
 		scheme = BIP84
-	} else if strings.HasPrefix(descriptor, "pkh(") {
+	case strings.HasPrefix(descriptor, "pkh("):
 		scheme = BIP44
-	} else {
+	default:
 		return DescriptorTokens{}, errors.Wrapf(ErrUnrecognizedScheme,
 			"failed to parse descriptor %v", descriptor)
 	}

--- a/pkg/keystore/descriptor_test.go
+++ b/pkg/keystore/descriptor_test.go
@@ -1,9 +1,10 @@
 package keystore
 
 import (
-	"github.com/pkg/errors"
 	"reflect"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestParseDescriptor(t *testing.T) {

--- a/pkg/keystore/memory.go
+++ b/pkg/keystore/memory.go
@@ -3,6 +3,7 @@ package keystore
 import (
 	"context"
 	"encoding/hex"
+
 	"github.com/ledgerhq/bitcoin-keychain-svc/bitcoin"
 	"github.com/pkg/errors"
 )
@@ -86,7 +87,7 @@ func (s *InMemoryKeystore) Create(descriptor string) (KeychainInfo, error) {
 		InternalPublicKey:       internalPublicKey,
 		InternalChainCode:       internalChainCode,
 		MaxInternalIndex:        0,
-		LookaheadSize:           20,
+		LookaheadSize:           lookaheadSize,
 		Scheme:                  tokens.Scheme,
 	}
 

--- a/pkg/keystore/memory_test.go
+++ b/pkg/keystore/memory_test.go
@@ -2,10 +2,11 @@ package keystore
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"reflect"
 	"strconv"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/ledgerhq/bitcoin-keychain-svc/bitcoin"
 	"google.golang.org/grpc"

--- a/pkg/keystore/store.go
+++ b/pkg/keystore/store.go
@@ -23,6 +23,8 @@ const (
 	BIP84 Scheme = "BIP84"
 )
 
+const lookaheadSize = 20
+
 // KeychainInfo models the global information related to an account registered
 // in the keystore.
 //


### PR DESCRIPTION
###  What is this about?

* Improved protobuf lint checks using [buf.build](https://buf.build).
* Added more linters to be to `mage lint` command.
* Fixed some lint errors reported by the  updated  `mage lint`.
* Enabled CI with GitHub Actions with the following steps:
  - Check if the `.proto` file can be compiled.
  - Check for lint errors in the  `.proto` file.
  - Check if the project can be built.
  - Run unit-tests with race detector and code-coverage enabled.
  - Upload coverage report to codecov.io

| [CI logs](https://github.com/LedgerHQ/bitcoin-keychain-svc/runs/1050894425?check_suite_focus=true) | [Coverage report](https://codecov.io/gh/LedgerHQ/bitcoin-keychain-svc/branch/keystore) |
-|-

### Cute picture of animal

![](https://media1.tenor.com/images/8236a4b8d6aa842a0f8046752b236e4a/tenor.gif?itemid=5125486)