### PR TITLE
keystore: implement MarkPathAsUsed for handling gaps

### DIFF
--- a/grpc/adapters.go
+++ b/grpc/adapters.go
@@ -30,14 +30,16 @@ func KeychainInfo(value keystore.KeychainInfo) *pb.KeychainInfo {
 		Xpub:                      value.XPub,
 		Slip32ExtendedPublicKey:   value.SLIP32ExtendedPublicKey,
 		ExternalXpub:              value.ExternalXPub,
-		ExternalFreshAddressIndex: value.ExternalFreshAddressIndex,
+		ExternalFreshAddressIndex: value.MaxConsecutiveExternalIndex,
 		InternalXpub:              value.InternalXPub,
-		InternalFreshAddressIndex: value.InternalFreshAddressIndex,
+		InternalFreshAddressIndex: value.MaxConsecutiveInternalIndex,
 		LookaheadSize:             value.LookaheadSize,
 		Scheme:                    scheme,
 	}
 }
 
+// Network is an adapter function to convert a gRPC pb.BitcoinNetwork
+// to keystore.Network instance.
 func Network(params pb.BitcoinNetwork) (keystore.Network, error) {
 	switch params {
 	case pb.BitcoinNetwork_BITCOIN_NETWORK_MAINNET:
@@ -49,4 +51,15 @@ func Network(params pb.BitcoinNetwork) (keystore.Network, error) {
 	default:
 		return "", errors.Wrap(ErrUnrecognizedNetwork, fmt.Sprint(params))
 	}
+}
+
+// DerivationPath is an adapter function to convert a derivation path (slice)
+// to a keystore.DerivationPath instance.
+func DerivationPath(path []uint32) (keystore.DerivationPath, error) {
+	if len(path) != 2 {
+		return keystore.DerivationPath{}, errors.Wrap(
+			ErrInvalidDerivationPath, fmt.Sprintf("%v", path))
+	}
+
+	return keystore.DerivationPath{path[0], path[1]}, nil
 }

--- a/grpc/errors.go
+++ b/grpc/errors.go
@@ -6,4 +6,8 @@ var (
 	// ErrUnrecognizedNetwork indicates that an unrecognized Bitcoin network,
 	// defined in the keychain service, was encountered.
 	ErrUnrecognizedNetwork = errors.New("unrecognized keychain network")
+
+	// ErrInvalidDerivationPath indicates that a derivation path is invalid or
+	// malformed.
+	ErrInvalidDerivationPath = errors.New("invalid derivation path")
 )

--- a/grpc/keychain.go
+++ b/grpc/keychain.go
@@ -47,6 +47,21 @@ func (c Controller) GetKeychainInfo(
 	return KeychainInfo(r), nil
 }
 
+func (c Controller) MarkPathAsUsed(
+	ctx context.Context, request *pb.MarkPathAsUsedRequest,
+) (*emptypb.Empty, error) {
+	path, err := DerivationPath(request.Derivation)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.store.MarkPathAsUsed(request.AccountDescriptor, path); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
 // NewKeychainController returns a new instance of a Controller struct that
 // implements the pb.KeychainServiceServer interface.
 func NewKeychainController() *Controller {

--- a/pb/v1/service.proto
+++ b/pb/v1/service.proto
@@ -15,6 +15,9 @@ service KeychainService {
 
   // Get keychain metadata.
   rpc GetKeychainInfo(GetKeychainInfoRequest) returns (KeychainInfo) {}
+
+  // Mark derivation path as used
+  rpc MarkPathAsUsed(MarkPathAsUsedRequest) returns (google.protobuf.Empty) {}
 }
 
 // BitcoinNetwork enumerates the list of all supported Bitcoin networks. It
@@ -93,4 +96,16 @@ message KeychainInfo {
   // This field is mostly useful for encoding addresses for a specific
   // network.
   BitcoinNetwork network = 12;
+}
+
+message MarkPathAsUsedRequest {
+  // Account descriptor of the keychain
+  string account_descriptor = 1;
+
+  // Derivation path relative to BIP-32 account path-level.
+  //
+  // The derivation path is represented by an array of child indexes. Each
+  // child index in the path must be between 0 and 2^31-1, i.e., they should
+  // not be hardened.
+  repeated uint32 derivation = 2;
 }

--- a/pkg/keystore/bip32.go
+++ b/pkg/keystore/bip32.go
@@ -22,8 +22,12 @@ type DerivationPath [2]uint32
 
 // ChangeIndex returns the change index at BIP32 path-level 4, from a given
 // DerivationPath.
-func (path DerivationPath) ChangeIndex() uint32 {
-	return path[0]
+func (path DerivationPath) ChangeIndex() Change {
+	if path[0] == 0 {
+		return External
+	}
+
+	return Internal // path[0] is 1
 }
 
 // ChangeIndex returns the address index at BIP32 path-level 5, from a given

--- a/pkg/keystore/memory.go
+++ b/pkg/keystore/memory.go
@@ -62,19 +62,19 @@ func (s *InMemoryKeystore) Create(descriptor string, net Network) (KeychainInfo,
 	}
 
 	keychainInfo := KeychainInfo{
-		Descriptor:                descriptor,
-		XPub:                      tokens.XPub,
-		SLIP32ExtendedPublicKey:   tokens.XPub, // TODO: Convert XPub to SLIP-0132 form
-		ExternalXPub:              externalChild.ExtendedKey,
-		ExternalFreshAddressIndex: 0,
-		InternalXPub:              internalChild.ExtendedKey,
-		InternalFreshAddressIndex: 0,
-		LookaheadSize:             lookaheadSize,
-		Scheme:                    tokens.Scheme,
-		Network:                   net,
+		Descriptor:                  descriptor,
+		XPub:                        tokens.XPub,
+		SLIP32ExtendedPublicKey:     tokens.XPub, // TODO: Convert XPub to SLIP-0132 form
+		ExternalXPub:                externalChild.ExtendedKey,
+		MaxConsecutiveExternalIndex: 0,
+		InternalXPub:                internalChild.ExtendedKey,
+		MaxConsecutiveInternalIndex: 0,
+		LookaheadSize:               lookaheadSize,
+		Scheme:                      tokens.Scheme,
+		Network:                     net,
 	}
 
-	s.db[descriptor] = Meta{
+	s.db[descriptor] = &Meta{
 		Main:        keychainInfo,
 		Derivations: nil,
 		Addresses:   nil,
@@ -87,40 +87,25 @@ func (s *InMemoryKeystore) Create(descriptor string, net Network) (KeychainInfo,
 // given Change index, for the keychain corresponding to the provided
 // descriptor.
 //
-// See GetFreshAddresses for getting fresh addresses in bulk.
-//
-// This is a read-only operation.
+// See GetFreshAddresses for getting fresh addresses in bulk, and for further
+// details.
 func (s InMemoryKeystore) GetFreshAddress(descriptor string, change Change) (string, error) {
-	k, ok := s.db[descriptor]
-	if !ok {
-		return "", ErrDescriptorNotFound
-	}
-
-	changeXPub, err := k.ChangeXPub(change)
+	addrs, err := s.GetFreshAddresses(descriptor, change, 1)
 	if err != nil {
 		return "", err
 	}
 
-	freshAddressIndex, err := k.FreshAddressIndex(change)
-	if err != nil {
-		return "", err
-	}
-
-	addr, err := deriveAddressAtIndex(s.client, changeXPub, freshAddressIndex,
-		k.Main.Scheme, k.Main.Network)
-	if err != nil {
-		return "", err
-	}
-
-	return addr, nil
+	return addrs[0], nil
 }
 
 // GetFreshAddresses retrieves bulk fresh addresses from the in-memory keystore.
 //
-// See GetFreshAddress for further details.
-//
-// This is a read-only operation.
-func (s InMemoryKeystore) GetFreshAddresses(descriptor string, change Change, size uint32) ([]string, error) {
+// In addition to ensuring that issued addresses are always fresh (unused), the
+// method also detects gaps in used addresses and includes it in fresh address
+// list.
+func (s InMemoryKeystore) GetFreshAddresses(
+	descriptor string, change Change, size uint32,
+) ([]string, error) {
 	addrs := []string{}
 
 	k, ok := s.db[descriptor]
@@ -133,20 +118,152 @@ func (s InMemoryKeystore) GetFreshAddresses(descriptor string, change Change, si
 		return addrs, err
 	}
 
-	freshAddressIndex, err := k.FreshAddressIndex(change)
+	maxConsecutiveIndex, err := k.MaxConsecutiveIndex(change)
 	if err != nil {
 		return addrs, err
 	}
 
-	for i := uint32(0); i < size; i++ {
-		addr, err := deriveAddressAtIndex(s.client, changeXPub, freshAddressIndex+i,
-			k.Main.Scheme, k.Main.Network)
-		if err != nil {
-			return addrs, err
-		}
+	nonConsecutiveIndexes, err := k.NonConsecutiveIndexes(change)
+	if err != nil {
+		return nil, err
+	}
 
-		addrs = append(addrs, addr)
+	for i := uint32(0); uint32(len(addrs)) < size; i++ {
+		index := maxConsecutiveIndex + i
+
+		// Skip any index that exists in non-consecutive indexes, to prevent
+		// address reuse.
+		if !contains(nonConsecutiveIndexes, index) {
+			addr, err := deriveAddressAtIndex(s.client, changeXPub, index,
+				k.Main.Scheme, k.Main.Network)
+			if err != nil {
+				return addrs, err
+			}
+
+			addrs = append(addrs, addr)
+		}
 	}
 
 	return addrs, nil
+}
+
+// MarkPathAsUsed sets a given derivation path as used. It records bookkeeping
+// information about gaps in the derivation.
+//
+// A derivation path is considered "used" if it has transaction history.
+//
+// If marking of a derivation path as used introduces any gaps, they are
+// detected and saved in the keystore. For this we rely on two main fields:
+//   MaxConsecutiveIndex   -> the largest consecutive index without any gaps
+//   NonConsecutiveIndexes -> list of used indexes that introduced gaps
+func (s *InMemoryKeystore) MarkPathAsUsed(descriptor string, path DerivationPath) error {
+	// Get keychain by descriptor
+	k, ok := s.db[descriptor]
+	if !ok {
+		return ErrDescriptorNotFound
+	}
+
+	change := path.ChangeIndex()
+
+	maxConsecutiveIndex, err := k.MaxConsecutiveIndex(change)
+	if err != nil {
+		return err
+	}
+
+	nonConsecutiveIndexes, err := k.NonConsecutiveIndexes(change)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	// CASE 1: Address index being marked as used already falls within the
+	// range of consecutive indexes. This is typically when an address index
+	// is marked as used twice.
+	case path.AddressIndex() < maxConsecutiveIndex:
+		// Nothing to do in this case.
+
+	// CASE 2: Mark as used at the boundary of the consecutive used indexes, by
+	// incrementing the max consecutive index.
+	case path.AddressIndex() == maxConsecutiveIndex:
+		maxConsecutiveIndex++
+
+		// Handle case when the max consecutive index overreaches into the
+		// non-consecutive indexes. This typically happens when a gap is filled
+		// by marking the gap address index as used.
+		//
+		// Repeat this step until the max consecutive index is outside the
+		// overlap of non-consecutive indexes, where it is safe to issue a
+		// fresh address.
+		for contains(nonConsecutiveIndexes, maxConsecutiveIndex) {
+			maxConsecutiveIndex++
+		}
+
+		// Save the max consecutive index. It is important to perform this step
+		// before saving the non-consecutive indexes.
+		if err := k.SetMaxConsecutiveIndex(change, maxConsecutiveIndex); err != nil {
+			return err
+		}
+
+		// Reconcile non-consecutive indexes depending on the updated state of
+		// the max consecutive index.
+		//
+		// TODO: Implement a dedicated method for this reconciliation, since the
+		//       non-consecutive indexes are never changed until this step.
+		if err := k.SetNonConsecutiveIndexes(change, nonConsecutiveIndexes); err != nil {
+			return err
+		}
+
+	// CASE 3: Attempt to introduce a gap after the max consecutive index.
+	//
+	// Consider the following list of address indexes as the state of the
+	// keychain. * indicates that an index is used.
+	//
+	// Before:
+	//   state                  : 0*  1  2  3  4  5
+	//   max consecutive index  : 1
+	//   non-consecutive indexes: []
+	//
+	// After: mark index 2 as used
+	//   state                  : 0*  1  2*  3  4  5
+	//   max consecutive index  : 1   <- no change
+	//   non-consecutive indexes: [2] <- add the index that created a gap
+	case path.AddressIndex() > maxConsecutiveIndex:
+		// Add address index to list of non-consecutive indexes (if does not
+		// exist already).
+		if !contains(nonConsecutiveIndexes, path.AddressIndex()) {
+			nonConsecutiveIndexes = append(
+				nonConsecutiveIndexes, path.AddressIndex())
+
+			err := k.SetNonConsecutiveIndexes(change, nonConsecutiveIndexes)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *InMemoryKeystore) GetAllObservableIndexes(
+	descriptor string, change Change, from uint32, to uint32,
+) ([]uint32, error) {
+	k, ok := s.db[descriptor]
+	if !ok {
+		return nil, ErrDescriptorNotFound
+	}
+
+	maxObservableIndex, err := k.MaxObservableIndex(change)
+	if err != nil {
+		return nil, err
+	}
+
+	length := minUint32(to-from, maxObservableIndex-from)
+
+	var result []uint32
+
+	for i := uint32(0); i <= length; i++ {
+		result = append(result, from+i)
+	}
+
+	return result, nil
 }

--- a/pkg/keystore/utils.go
+++ b/pkg/keystore/utils.go
@@ -1,0 +1,19 @@
+package keystore
+
+func contains(s []uint32, e uint32) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+
+	return false
+}
+
+func minUint32(a uint32, b uint32) uint32 {
+	if a < b {
+		return a
+	}
+
+	return b
+}


### PR DESCRIPTION
### What is this about?

|JIRA| [BACK-760](https://ledgerhq.atlassian.net/browse/BACK-760) | [BACK-761](https://ledgerhq.atlassian.net/browse/BACK-761) |
-|-|-

This PR introduces the `MarkPathAsUsed` method that allows the caller to set a given derivation path as used, in the `keystore`. It keeps track of gaps introduced by used address. This is done by maintaining 2 data-structures, each for internal and external change paths  -  one for storing the max consecutive index, and the other for storing non-consecutive indexes.

Also improved the `GetFreshAddresses` method to ensure gaps are actively filled while issuing new unused addresses.

### Cute picture of animal

![](https://media.tenor.com/images/568a4a571c5bc93a138789549512177e/tenor.gif)