### PR TITLE
Implement integration test suite for keychain registration

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,46 @@
+name: Integration tests
+on: [push, pull_request]
+jobs:
+  build:
+    name: Go CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Install mage
+        run: "pushd /tmp; git clone https://github.com/magefile/mage; pushd mage; go run bootstrap.go; popd; popd"
+
+      - name: Install Protobuf compiler
+        uses: arduino/setup-protoc@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Protobuf Go plugin
+        run: |
+          go get github.com/golang/protobuf/protoc-gen-go
+
+      - name: Check out bitcoin-svc
+        uses: actions/checkout@master
+        with:
+          repository: LedgerHQ/bitcoin-svc
+          path: 'bitcoin-svc'
+
+      - name: Run bitcoin-svc in the background
+        run: |
+          pushd bitcoin-svc
+          mage -v build
+          ./lbs &
+          popd
+
+      - name: Build
+        run: |
+          mage -v build
+
+      - name: Run integration tests
+        run: mage -v integration

--- a/grpc/adapters.go
+++ b/grpc/adapters.go
@@ -73,3 +73,16 @@ func DerivationPath(path []uint32) (keystore.DerivationPath, error) {
 
 	return keystore.DerivationPath{path[0], path[1]}, nil
 }
+
+// Change is an adapter function to convert a gRPC pb.Change to an instance of
+// keystore.Change.
+func Change(change pb.Change) (keystore.Change, error) {
+	switch change {
+	case pb.Change_CHANGE_EXTERNAL:
+		return keystore.External, nil
+	case pb.Change_CHANGE_INTERNAL:
+		return keystore.Internal, nil
+	default:
+		return -1, errors.Wrap(ErrUnrecognizedChange, fmt.Sprint(change))
+	}
+}

--- a/grpc/errors.go
+++ b/grpc/errors.go
@@ -7,6 +7,10 @@ var (
 	// defined in the keychain service, was encountered.
 	ErrUnrecognizedNetwork = errors.New("unrecognized keychain network")
 
+	// ErrUnrecognizedChange indicates that an unrecognized Change path was
+	// encountered.
+	ErrUnrecognizedChange = errors.New("unrecognized change")
+
 	// ErrInvalidDerivationPath indicates that a derivation path is invalid or
 	// malformed.
 	ErrInvalidDerivationPath = errors.New("invalid derivation path")

--- a/grpc/keychain.go
+++ b/grpc/keychain.go
@@ -62,6 +62,23 @@ func (c Controller) MarkPathAsUsed(
 	return nil, nil
 }
 
+func (c Controller) GetFreshAddresses(
+	ctx context.Context, request *pb.GetFreshAddressesRequest,
+) (*pb.GetFreshAddressesResponse, error) {
+	change, err := Change(request.Change)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs, err := c.store.GetFreshAddresses(
+		request.AccountDescriptor, change, request.BatchSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.GetFreshAddressesResponse{Addresses: addrs}, nil
+}
+
 // NewKeychainController returns a new instance of a Controller struct that
 // implements the pb.KeychainServiceServer interface.
 func NewKeychainController() *Controller {

--- a/integration/create_keychain_test.go
+++ b/integration/create_keychain_test.go
@@ -1,0 +1,123 @@
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+
+	pb "github.com/ledgerhq/bitcoin-keychain-svc/pb/keychain"
+)
+
+func TestKeychainRegistration(t *testing.T) {
+	ctx := context.Background()
+	client, conn := keychainSvcClient(ctx)
+	defer conn.Close()
+
+	tests := []struct {
+		name            string
+		fixture         Fixture
+		externalAddress *pb.GetFreshAddressesResponse
+		internalAddress *pb.GetFreshAddressesResponse
+		wantErr         error
+	}{
+		{
+			name:    "bitcoin mainnet p2pkh",
+			fixture: BitcoinMainnetP2PKH,
+			externalAddress: &pb.GetFreshAddressesResponse{
+				Addresses: []string{"151krzHgfkNoH3XHBzEVi6tSn4db7pVjmR"},
+			},
+			internalAddress: &pb.GetFreshAddressesResponse{
+				Addresses: []string{"13hSrTAvfRzyEcjRcGS5gLEcNVNDhPvvUv"},
+			},
+		},
+		{
+			name:    "bitcoin testnet3 p2pkh",
+			fixture: BitcoinTestnet3P2PKH,
+			externalAddress: &pb.GetFreshAddressesResponse{
+				Addresses: []string{"mkpZhYtJu2r87Js3pDiWJDmPte2NRZ8bJV"},
+			},
+			internalAddress: &pb.GetFreshAddressesResponse{
+				Addresses: []string{"mi8nhzZgGZQthq6DQHbru9crMDerUdTKva"},
+			},
+		},
+		{
+			name:    "bitcoin testnet3 p2sh-p2wpkh",
+			fixture: BitcoinTestnet3P2SHP2WPKH,
+			externalAddress: &pb.GetFreshAddressesResponse{
+				Addresses: []string{"2MvuUMAG1NFQmmM69Writ6zTsYCnQHFG9BF"},
+			},
+			internalAddress: &pb.GetFreshAddressesResponse{
+				Addresses: []string{"2MsMvWTbPMg4eiSudDa5i7y8XNC8fLCok3c"},
+			},
+		},
+		{
+			name:    "bitcoin testnet3 p2wpkh",
+			fixture: BitcoinMainnetP2WPKH,
+			externalAddress: &pb.GetFreshAddressesResponse{
+				Addresses: []string{"bc1qh4kl0a0a3d7su8udc2rn62f8w939prqpl34z86"},
+			},
+			internalAddress: &pb.GetFreshAddressesResponse{
+				Addresses: []string{"bc1qry3crfssh8w6guajms7upclgqsfac4fs4g7nwj"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.CreateKeychain(ctx, &pb.CreateKeychainRequest{
+				AccountDescriptor: tt.fixture.Descriptor,
+				LookaheadSize:     20,
+				Network:           tt.fixture.Network,
+			})
+			if err != nil {
+				t.Fatalf("failed to create keychain - error = %v", err)
+			}
+
+			wantKeychainInfo := &pb.KeychainInfo{
+				AccountDescriptor:       tt.fixture.Descriptor,
+				Xpub:                    tt.fixture.XPub,
+				Slip32ExtendedPublicKey: tt.fixture.XPub,
+				LookaheadSize:           20,
+				Scheme:                  tt.fixture.Scheme,
+				Network:                 tt.fixture.Network,
+			}
+
+			if !proto.Equal(got, wantKeychainInfo) {
+				t.Fatalf("CreateKeychain() got = '%v', want = '%v'",
+					got, wantKeychainInfo)
+			}
+
+			gotExtAddr, err := client.GetFreshAddresses(
+				ctx, &pb.GetFreshAddressesRequest{
+					AccountDescriptor: tt.fixture.Descriptor,
+					Change:            pb.Change_CHANGE_EXTERNAL,
+					BatchSize:         1,
+				})
+			if err != nil {
+				t.Fatalf("failed to get fresh external addr - error = %v", err)
+			}
+
+			if !proto.Equal(gotExtAddr, tt.externalAddress) {
+				t.Fatalf("GetFreshAddresses() got = '%v', want = '%v'",
+					gotExtAddr.Addresses, tt.externalAddress.Addresses)
+			}
+
+			gotIntAddr, err := client.GetFreshAddresses(
+				ctx, &pb.GetFreshAddressesRequest{
+					AccountDescriptor: tt.fixture.Descriptor,
+					Change:            pb.Change_CHANGE_INTERNAL,
+					BatchSize:         1,
+				})
+			if err != nil {
+				t.Fatalf("failed to get fresh internal addr - error = %v", err)
+			}
+
+			if !proto.Equal(gotIntAddr, tt.internalAddress) {
+				t.Fatalf("GetFreshAddresses() got = '%v', want = '%v'",
+					gotIntAddr.Addresses, tt.internalAddress.Addresses)
+			}
+		})
+	}
+}

--- a/integration/fixtures.go
+++ b/integration/fixtures.go
@@ -1,0 +1,38 @@
+package integration
+
+import pb "github.com/ledgerhq/bitcoin-keychain-svc/pb/keychain"
+
+type Fixture struct {
+	Descriptor string
+	XPub       string
+	Network    pb.BitcoinNetwork
+	Scheme     pb.KeychainInfo_Scheme
+}
+
+var BitcoinMainnetP2PKH = Fixture{
+	Descriptor: "pkh(xpub6DCi5iJ57ZPd5qPzvTm5hUt6X23TJdh9H4NjNsNbt7t7UuTMJfawQWsdWRFhfLwkiMkB1rQ4ZJWLB9YBnzR7kbs9N8b2PsKZgKUHQm1X4or)",
+	XPub:       "xpub6DCi5iJ57ZPd5qPzvTm5hUt6X23TJdh9H4NjNsNbt7t7UuTMJfawQWsdWRFhfLwkiMkB1rQ4ZJWLB9YBnzR7kbs9N8b2PsKZgKUHQm1X4or",
+	Network:    pb.BitcoinNetwork_BITCOIN_NETWORK_MAINNET,
+	Scheme:     pb.KeychainInfo_SCHEME_BIP44,
+}
+
+var BitcoinTestnet3P2PKH = Fixture{
+	Descriptor: "pkh(tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba)",
+	XPub:       "tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba",
+	Network:    pb.BitcoinNetwork_BITCOIN_NETWORK_TESTNET3,
+	Scheme:     pb.KeychainInfo_SCHEME_BIP44,
+}
+
+var BitcoinTestnet3P2SHP2WPKH = Fixture{
+	Descriptor: "sh(wpkh(tpubDCcvqEHx7prGddpWTfEviiew5YLMrrKy4oJbt14teJZenSi6AYMAs2SNXwYXFzkrNYwECSmobwxESxMCrpfqw4gsUt88bcr8iMrJmbb8P2q))",
+	XPub:       "tpubDCcvqEHx7prGddpWTfEviiew5YLMrrKy4oJbt14teJZenSi6AYMAs2SNXwYXFzkrNYwECSmobwxESxMCrpfqw4gsUt88bcr8iMrJmbb8P2q",
+	Network:    pb.BitcoinNetwork_BITCOIN_NETWORK_TESTNET3,
+	Scheme:     pb.KeychainInfo_SCHEME_BIP49,
+}
+
+var BitcoinMainnetP2WPKH = Fixture{
+	Descriptor: "wpkh(xpub6CMeLkY9TzXyLYXPWMXB5LWtprVABb6HwPEPXnEgESMNrSUBsvhXNsA7zKS1ZRKhUyQG4HjZysEP8v7gDNU4J6PvN5yLx4meEm3mpEapLMN)",
+	XPub:       "xpub6CMeLkY9TzXyLYXPWMXB5LWtprVABb6HwPEPXnEgESMNrSUBsvhXNsA7zKS1ZRKhUyQG4HjZysEP8v7gDNU4J6PvN5yLx4meEm3mpEapLMN",
+	Network:    pb.BitcoinNetwork_BITCOIN_NETWORK_MAINNET,
+	Scheme:     pb.KeychainInfo_SCHEME_BIP84,
+}

--- a/integration/harness.go
+++ b/integration/harness.go
@@ -1,0 +1,60 @@
+package integration
+
+import (
+	"context"
+	"net"
+
+	pb "github.com/ledgerhq/bitcoin-keychain-svc/pb/keychain"
+
+	controllers "github.com/ledgerhq/bitcoin-keychain-svc/grpc"
+	"github.com/ledgerhq/bitcoin-keychain-svc/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+const bufSize = 1024 * 1024
+
+var lis *bufconn.Listener
+
+// launch at package initialization
+func init() {
+	startKeychainSvc()
+}
+
+// startKeychainSvc launches a keychain gRPC server over a buffered connection.
+// This allows us to use a full-blown server for tests, without reserving a
+// TCP port for the same.
+//
+// gRPC client can use the same connection to dial to the server.
+func startKeychainSvc() {
+	lis = bufconn.Listen(bufSize)
+	s := grpc.NewServer()
+
+	keychainController := controllers.NewKeychainController()
+	pb.RegisterKeychainServiceServer(s, keychainController)
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			log.Fatalf("Server exited with error: %v", err)
+		}
+	}()
+}
+
+// connect to buffered connection.
+func bufDialer(context.Context, string) (net.Conn, error) {
+	return lis.Dial()
+}
+
+// keychainSvcClient connects to the keychain gRPC service via a buffered
+// connection.
+func keychainSvcClient(ctx context.Context) (pb.KeychainServiceClient, *grpc.ClientConn) {
+	conn, err := grpc.DialContext(
+		ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("Failed to dial bufnet: %v", err)
+	}
+
+	client := pb.NewKeychainServiceClient(conn)
+
+	return client, conn
+}

--- a/integration/main.go
+++ b/integration/main.go
@@ -1,0 +1,10 @@
+package integration
+
+// This file only exists to prevent warnings due to no buildable source files
+// when the build tag for enabling the tests is not specified.
+
+// Suppress unused/deadcode warnings when package side-effects are not invoked,
+// for example while running linters.
+var (
+	_ = keychainSvcClient
+)

--- a/magefile.go
+++ b/magefile.go
@@ -87,6 +87,11 @@ func Test() error {
 	return sh.Run(goexe, "test", "./...")
 }
 
+// Run integration tests
+func Integration() error {
+	return sh.Run(goexe, "test", "--tags=integration", "./...")
+}
+
 // Run tests with race detector
 func TestRace() error {
 	return sh.Run(goexe, "test", "-race", "./...")

--- a/pb/keychain/service.proto
+++ b/pb/keychain/service.proto
@@ -18,6 +18,9 @@ service KeychainService {
 
   // Mark derivation path as used
   rpc MarkPathAsUsed(MarkPathAsUsedRequest) returns (google.protobuf.Empty) {}
+
+  // Get fresh addresses for a registered keychain and the provided Change.
+  rpc GetFreshAddresses(GetFreshAddressesRequest) returns (GetFreshAddressesResponse) {}
 }
 
 // BitcoinNetwork enumerates the list of all supported Bitcoin networks. It
@@ -32,6 +35,14 @@ enum BitcoinNetwork {
   BITCOIN_NETWORK_MAINNET     = 1;  // Main network
   BITCOIN_NETWORK_TESTNET3    = 2;  // Current test network (since Bitcoin Core v0.7)
   BITCOIN_NETWORK_REGTEST     = 3;  // Regression test network
+}
+
+// Change is an enum type to indicate whether an address belongs to the
+// external chain (receive) or the internal chain (change).
+enum Change {
+  CHANGE_UNSPECIFIED = 0;  // fallback value if unrecognized / unspecified
+  CHANGE_EXTERNAL    = 1;  // external chain
+  CHANGE_INTERNAL    = 2;  // internal chain
 }
 
 message CreateKeychainRequest {
@@ -62,7 +73,7 @@ message KeychainInfo {
   string slip32_extended_public_key = 3;
 
   // Numerical size of the lookahead zone.
-  uint32 lookahead_size = 10;
+  uint32 lookahead_size = 4;
 
   // Scheme defines the scheme on which a keychain entry is based.
   enum Scheme {
@@ -71,7 +82,7 @@ message KeychainInfo {
     SCHEME_BIP49       = 2;  // indicates that the keychain scheme is segwit.
     SCHEME_BIP84       = 3;  // indicates that the keychain scheme is native segwit.
   }
-  Scheme scheme = 11;
+  Scheme scheme = 5;
 
   // Network for which the keychain is defined.
   //
@@ -81,7 +92,7 @@ message KeychainInfo {
   //
   // This field is mostly useful for encoding addresses for a specific
   // network.
-  BitcoinNetwork network = 12;
+  BitcoinNetwork network = 6;
 }
 
 message MarkPathAsUsedRequest {
@@ -94,4 +105,19 @@ message MarkPathAsUsedRequest {
   // child index in the path must be between 0 and 2^31-1, i.e., they should
   // not be hardened.
   repeated uint32 derivation = 2;
+}
+
+message GetFreshAddressesRequest {
+  // Account descriptor of the keychain
+  string account_descriptor = 1;
+
+  // The chain on which the fresh addresses must be issued on.
+  Change change = 2;
+
+  // The number of fresh addresses to derive.
+  uint32 batch_size = 3;
+}
+
+message GetFreshAddressesResponse {
+  repeated string addresses = 1;
 }

--- a/pkg/keystore/descriptor_test.go
+++ b/pkg/keystore/descriptor_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package keystore
 
 import (

--- a/pkg/keystore/memory_test.go
+++ b/pkg/keystore/memory_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package keystore
 
 import (


### PR DESCRIPTION
### What is this about?

Implemented a basic framework to run integration tests, against the keychain gRPC server and utilizing [bitcoin-svc](https://github.com/LedgerHQ/bitcoin-svc).

In this PR, we have integration tests for registering keychains and obtaining the first fresh address; which is mostly a port from libcore (and more!). In the next PR, we'll have more sophisticated tests for gap management, relying on listing the observable address, etc.

### Cute picture of animal

![](https://media.tenor.com/images/14da321584fa8af25dff5e2f54280363/tenor.gif)