### PR TITLE
grpc: add endpoints MarkAddressesAsUsed and GetAllObservableAddresses

### DIFF
--- a/grpc/keychain.go
+++ b/grpc/keychain.go
@@ -47,21 +47,6 @@ func (c Controller) GetKeychainInfo(
 	return KeychainInfo(r), nil
 }
 
-func (c Controller) MarkPathAsUsed(
-	ctx context.Context, request *pb.MarkPathAsUsedRequest,
-) (*emptypb.Empty, error) {
-	path, err := DerivationPath(request.Derivation)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := c.store.MarkPathAsUsed(request.AccountDescriptor, path); err != nil {
-		return nil, err
-	}
-
-	return nil, nil
-}
-
 func (c Controller) GetFreshAddresses(
 	ctx context.Context, request *pb.GetFreshAddressesRequest,
 ) (*pb.GetFreshAddressesResponse, error) {
@@ -77,6 +62,35 @@ func (c Controller) GetFreshAddresses(
 	}
 
 	return &pb.GetFreshAddressesResponse{Addresses: addrs}, nil
+}
+
+func (c Controller) MarkAddressesAsUsed(
+	ctx context.Context, request *pb.MarkAddressesAsUsedRequest,
+) (*emptypb.Empty, error) {
+	for _, addr := range request.Addresses {
+		if err := c.store.MarkAddressAsUsed(request.AccountDescriptor, addr); err != nil {
+			return nil, err
+		}
+	}
+
+	return &emptypb.Empty{}, nil
+}
+
+func (c Controller) GetAllObservableAddresses(
+	ctx context.Context, request *pb.GetAllObservableAddressesRequest,
+) (*pb.GetAllObservableAddressesResponse, error) {
+	change, err := Change(request.Change)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs, err := c.store.GetAllObservableAddresses(
+		request.AccountDescriptor, change, request.FromIndex, request.ToIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.GetAllObservableAddressesResponse{Addresses: addrs}, nil
 }
 
 // NewKeychainController returns a new instance of a Controller struct that

--- a/integration/p2pkh_keychain_test.go
+++ b/integration/p2pkh_keychain_test.go
@@ -1,0 +1,92 @@
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	pb "github.com/ledgerhq/bitcoin-keychain-svc/pb/keychain"
+)
+
+func TestP2PKHKeychainTest(t *testing.T) {
+	ctx := context.Background()
+	client, conn := keychainSvcClient(ctx)
+	defer conn.Close()
+
+	if _, err := client.CreateKeychain(ctx, &pb.CreateKeychainRequest{
+		AccountDescriptor: BitcoinMainnetP2PKH.Descriptor,
+		LookaheadSize:     20,
+		Network:           BitcoinMainnetP2PKH.Network,
+	}); err != nil {
+		t.Fatalf("failed to create keychain - error = %v", err)
+	}
+
+	gotObsAddrs, err := client.GetAllObservableAddresses(ctx, &pb.GetAllObservableAddressesRequest{
+		AccountDescriptor: BitcoinMainnetP2PKH.Descriptor,
+		Change:            pb.Change_CHANGE_EXTERNAL,
+		FromIndex:         0,
+		ToIndex:           10,
+	})
+	if err != nil {
+		t.Fatalf("failed to get addresses in observable range [1 10] - error = %v", err)
+	}
+
+	wantObsAddrs := &pb.GetAllObservableAddressesResponse{Addresses: []string{
+		"151krzHgfkNoH3XHBzEVi6tSn4db7pVjmR",
+		"18tMkbibtxJPQoTPUv8s3mSXqYzEsrbeRb",
+		"1GJr9FHZ1pbR4hjhX24M4L1BDUd2QogYYA",
+		"1KZB7aFfuZE2skJQPHH56VhSxUpUBjouwQ",
+		"1FyjDvDFcXLMmhMWD6u8bFovLgkhZabhTQ",
+		"1NGp18iPyWfSZz4AWnwT6HptDdVJfTjxnF",
+		"1L36ug5kWFLbMysfkAexh9LeicyMAteuEg",
+		"169V9snkmcdzpEDhRyLMnEuhLKyWdjzhfd",
+		"14K3JxsLwhpLiECaoJMsZYyk9peYP1Gtty",
+		"1GEix38AknUMWH8DYSn43HqodoB7RjyBAJ",
+		"1918hHSQNsNMRkDCUMy7DUmJ8GJzwfRkUV",
+	}}
+
+	if !proto.Equal(gotObsAddrs, wantObsAddrs) {
+		t.Fatalf("GetAllObservableAddresses() got = '%v', want = '%v'",
+			gotObsAddrs.Addresses, wantObsAddrs.Addresses)
+	}
+
+	gotReceiveAddr, err := client.GetFreshAddresses(
+		ctx, &pb.GetFreshAddressesRequest{
+			AccountDescriptor: BitcoinMainnetP2PKH.Descriptor,
+			Change:            pb.Change_CHANGE_EXTERNAL,
+			BatchSize:         1,
+		})
+	if err != nil {
+		t.Fatalf("failed to get fresh external addr - error = %v", err)
+	}
+
+	if gotReceiveAddr.Addresses[0] != "151krzHgfkNoH3XHBzEVi6tSn4db7pVjmR" {
+		t.Fatalf("GetFreshAddresses() got = '%v', want = '%v'",
+			gotReceiveAddr.Addresses, []string{"151krzHgfkNoH3XHBzEVi6tSn4db7pVjmR"})
+	}
+
+	if _, err := client.MarkAddressesAsUsed(
+		ctx, &pb.MarkAddressesAsUsedRequest{
+			AccountDescriptor: BitcoinMainnetP2PKH.Descriptor,
+			Addresses:         []string{"151krzHgfkNoH3XHBzEVi6tSn4db7pVjmR"},
+		}); err != nil {
+		t.Fatalf("MarkAddressesAsUsed() - error = %v", err)
+	}
+
+	gotNextReceiveAddr, err := client.GetFreshAddresses(
+		ctx, &pb.GetFreshAddressesRequest{
+			AccountDescriptor: BitcoinMainnetP2PKH.Descriptor,
+			Change:            pb.Change_CHANGE_EXTERNAL,
+			BatchSize:         1,
+		})
+	if err != nil {
+		t.Fatalf("failed to get fresh external addr - error = %v", err)
+	}
+
+	if gotNextReceiveAddr.Addresses[0] != "18tMkbibtxJPQoTPUv8s3mSXqYzEsrbeRb" {
+		t.Fatalf("GetFreshAddresses() got = '%v', want = '%v'",
+			gotNextReceiveAddr.Addresses, []string{"18tMkbibtxJPQoTPUv8s3mSXqYzEsrbeRb"})
+	}
+}

--- a/pb/keychain/service.proto
+++ b/pb/keychain/service.proto
@@ -16,11 +16,14 @@ service KeychainService {
   // Get keychain metadata.
   rpc GetKeychainInfo(GetKeychainInfoRequest) returns (KeychainInfo) {}
 
-  // Mark derivation path as used
-  rpc MarkPathAsUsed(MarkPathAsUsedRequest) returns (google.protobuf.Empty) {}
+  // Mark a batch of addresses as used.
+  rpc MarkAddressesAsUsed(MarkAddressesAsUsedRequest) returns (google.protobuf.Empty) {}
 
   // Get fresh addresses for a registered keychain and the provided Change.
   rpc GetFreshAddresses(GetFreshAddressesRequest) returns (GetFreshAddressesResponse) {}
+
+  // Get a list of all address that can be observed by the keychain.
+  rpc GetAllObservableAddresses(GetAllObservableAddressesRequest) returns (GetAllObservableAddressesResponse) {}
 }
 
 // BitcoinNetwork enumerates the list of all supported Bitcoin networks. It
@@ -119,5 +122,31 @@ message GetFreshAddressesRequest {
 }
 
 message GetFreshAddressesResponse {
+  repeated string addresses = 1;
+}
+
+message MarkAddressesAsUsedRequest {
+  // Account descriptor of the keychain
+  string account_descriptor = 1;
+
+  // Addresses to be marked as used
+  repeated string addresses = 2;
+}
+
+message GetAllObservableAddressesRequest {
+  // Account descriptor of the keychain
+  string account_descriptor = 1;
+
+  // The chain on which the observable addresses must be returned
+  Change change = 2;
+
+  // Start address index
+  uint32 from_index = 3;
+
+  // End address index
+  uint32 to_index = 4;
+}
+
+message GetAllObservableAddressesResponse {
   repeated string addresses = 1;
 }

--- a/pkg/keystore/errors.go
+++ b/pkg/keystore/errors.go
@@ -22,4 +22,8 @@ var (
 	// ErrDescriptorNotFound indicates an attempt to get a descriptor from a
 	// keystore that has not been registered.
 	ErrDescriptorNotFound = errors.New("descriptor not found")
+
+	// ErrAddressNotFound indicates that an address was not found in the
+	// address-to-derivations mapping in the keystore.
+	ErrAddressNotFound = errors.New("address not found")
 )


### PR DESCRIPTION
### What is this about?

Adding two new endpoints `MarkAddressesAsUsed` and `GetAllObservableAddresses`, for use in the synchronization worker.

### Cute picture of animal

![](https://media.tenor.com/images/9d10d93e708a1641033ac380b575af09/tenor.gif)