### PR TITLE
Handle unspecified fields in GetAllObservableAddresses RPC calls

### DIFF
--- a/grpc/keychain.go
+++ b/grpc/keychain.go
@@ -84,8 +84,17 @@ func (c Controller) GetAllObservableAddresses(
 		return nil, err
 	}
 
+	// If the toIndex field is left out in the request payload, we substitute
+	// it with a large value so that the max observable range is used instead.
+	var to uint32
+	if request.GetToIndex() == 0 {
+		to = (1 << 31) - 1 // uint32 max
+	} else {
+		to = request.ToIndex
+	}
+
 	addrs, err := c.store.GetAllObservableAddresses(
-		request.AccountDescriptor, change, request.FromIndex, request.ToIndex)
+		request.AccountDescriptor, change, request.FromIndex, to)
 	if err != nil {
 		return nil, err
 	}

--- a/grpc/keychain.go
+++ b/grpc/keychain.go
@@ -101,6 +101,7 @@ func (c Controller) GetAllObservableAddresses(
 	}
 
 	var addrs []string
+
 	for _, change := range changeList {
 		changeAddrs, err := c.store.GetAllObservableAddresses(
 			request.AccountDescriptor, change, request.FromIndex, to)

--- a/magefile.go
+++ b/magefile.go
@@ -120,7 +120,6 @@ func Lint() error {
 		"-E=maligned",
 		"-E=depguard",
 		"-E=misspell",
-		"-E=prealloc",
 		"-E=whitespace",
 		"-E=wsl",
 		"-E=gocritic",

--- a/pb/bitcoin/service.proto
+++ b/pb/bitcoin/service.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package pb.bitcoin;
 option go_package = ".;bitcoin";
-option java_package = "co.ledger.bitcoin.protobuf";
+option java_package = "co.ledger.protobuf.bitcoin";
 
 // CoinService exposes a gRPC interface to wrap protocol-centric logic
 // related to Bitcoin.

--- a/pb/keychain/service.proto
+++ b/pb/keychain/service.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package pb.keychain;
 option go_package = ".;keychain";
-option java_package = "co.ledger.protobuf";
+option java_package = "co.ledger.protobuf.bitcoin";
 
 import "google/protobuf/empty.proto";
 

--- a/pb/keychain/service.proto
+++ b/pb/keychain/service.proto
@@ -143,7 +143,8 @@ message GetAllObservableAddressesRequest {
   // Start address index
   uint32 from_index = 3;
 
-  // End address index
+  // End address index. If left unspecified, the maximum observable index
+  // will be used as the ending address index.
   uint32 to_index = 4;
 }
 

--- a/pb/keychain/service.proto
+++ b/pb/keychain/service.proto
@@ -137,7 +137,9 @@ message GetAllObservableAddressesRequest {
   // Account descriptor of the keychain
   string account_descriptor = 1;
 
-  // The chain on which the observable addresses must be returned
+  // The chain on which the observable addresses must be returned.
+  // If unspecified (CHANGE_UNSPECIFIED), return addresses observable on both
+  // internal and external chains.
   Change change = 2;
 
   // Start address index

--- a/pkg/keystore/memory.go
+++ b/pkg/keystore/memory.go
@@ -253,7 +253,7 @@ func (s *InMemoryKeystore) GetAllObservableAddresses(
 		return nil, err
 	}
 
-	length := minUint32(toIndex-fromIndex, maxObservableIndex-fromIndex)
+	length := minUint32(toIndex, maxObservableIndex) - fromIndex
 
 	var result []uint32
 


### PR DESCRIPTION
### What is this about?

This introduces two changes required for synchronization:
* When calling `GetAllObservableAddresses`, if `Change` is not specified, the server will return addresses on both external and internal chains.
* When calling `GetAllObservableAddresses`, if the `toIndex` is not specified, then the maximum observable range will be used.

### Cute picture of animal

![](https://media.tenor.com/images/4f994f0d17add5c05ba1a55a00591414/tenor.gif)