### PR TITLE
Replace account descriptors with UUIDs for identifying a keychain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/golang/protobuf v1.4.1
+	github.com/google/uuid v1.1.2
 	github.com/ledgerhq/bitcoin-keychain-svc/pb v0.1.0
 	github.com/magefile/mage v1.10.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -32,12 +32,14 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/ledgerhq/bitcoin-keychain-svc v0.0.0-20200810070336-b0a51ecc3f1d h1:ZoKEvnZbw2PMSWAxIvafcBe+q3Nab131iRQ1t9N+ucQ=
 github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
 github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
@@ -94,6 +96,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/grpc/errors.go
+++ b/grpc/errors.go
@@ -11,7 +11,15 @@ var (
 	// encountered.
 	ErrUnrecognizedChange = errors.New("unrecognized change")
 
+	// ErrUnrecognizedScheme indicates that an unrecognized derivation Scheme
+	// was encountered.
+	ErrUnrecognizedScheme = errors.New("unrecognized scheme")
+
 	// ErrInvalidDerivationPath indicates that a derivation path is invalid or
 	// malformed.
 	ErrInvalidDerivationPath = errors.New("invalid derivation path")
+
+	// ErrInvalidKeychainID indicates that the UUID representing the keychain
+	// could not be serialized / deserialized.
+	ErrInvalidKeychainID = errors.New("invalid keychain id")
 )

--- a/integration/create_keychain_test.go
+++ b/integration/create_keychain_test.go
@@ -66,56 +66,59 @@ func TestKeychainRegistration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := client.CreateKeychain(ctx, &pb.CreateKeychainRequest{
-				AccountDescriptor: tt.fixture.Descriptor,
+			info, err := client.CreateKeychain(ctx, &pb.CreateKeychainRequest{
+				ExtendedPublicKey: tt.fixture.ExtendedPublicKey,
 				LookaheadSize:     20,
 				Network:           tt.fixture.Network,
+				Scheme:            tt.fixture.Scheme,
 			})
 			if err != nil {
 				t.Fatalf("failed to create keychain - error = %v", err)
 			}
 
 			wantKeychainInfo := &pb.KeychainInfo{
-				AccountDescriptor:       tt.fixture.Descriptor,
-				Xpub:                    tt.fixture.XPub,
-				Slip32ExtendedPublicKey: tt.fixture.XPub,
+				KeychainId:              info.KeychainId,
+				InternalDescriptor:      tt.fixture.InternalDescriptor,
+				ExternalDescriptor:      tt.fixture.ExternalDescriptor,
+				ExtendedPublicKey:       tt.fixture.ExtendedPublicKey,
+				Slip32ExtendedPublicKey: tt.fixture.ExtendedPublicKey,
 				LookaheadSize:           20,
 				Scheme:                  tt.fixture.Scheme,
 				Network:                 tt.fixture.Network,
 			}
 
-			if !proto.Equal(got, wantKeychainInfo) {
-				t.Fatalf("CreateKeychain() got = '%v', want = '%v'",
-					got, wantKeychainInfo)
+			if !proto.Equal(info, wantKeychainInfo) {
+				t.Fatalf("CreateKeychain() info = '%v', want = '%v'",
+					info, wantKeychainInfo)
 			}
 
 			gotExtAddr, err := client.GetFreshAddresses(
 				ctx, &pb.GetFreshAddressesRequest{
-					AccountDescriptor: tt.fixture.Descriptor,
-					Change:            pb.Change_CHANGE_EXTERNAL,
-					BatchSize:         1,
+					KeychainId: info.KeychainId,
+					Change:     pb.Change_CHANGE_EXTERNAL,
+					BatchSize:  1,
 				})
 			if err != nil {
 				t.Fatalf("failed to get fresh external addr - error = %v", err)
 			}
 
 			if !proto.Equal(gotExtAddr, tt.externalAddress) {
-				t.Fatalf("GetFreshAddresses() got = '%v', want = '%v'",
+				t.Fatalf("GetFreshAddresses() info = '%v', want = '%v'",
 					gotExtAddr.Addresses, tt.externalAddress.Addresses)
 			}
 
 			gotIntAddr, err := client.GetFreshAddresses(
 				ctx, &pb.GetFreshAddressesRequest{
-					AccountDescriptor: tt.fixture.Descriptor,
-					Change:            pb.Change_CHANGE_INTERNAL,
-					BatchSize:         1,
+					KeychainId: info.KeychainId,
+					Change:     pb.Change_CHANGE_INTERNAL,
+					BatchSize:  1,
 				})
 			if err != nil {
 				t.Fatalf("failed to get fresh internal addr - error = %v", err)
 			}
 
 			if !proto.Equal(gotIntAddr, tt.internalAddress) {
-				t.Fatalf("GetFreshAddresses() got = '%v', want = '%v'",
+				t.Fatalf("GetFreshAddresses() info = '%v', want = '%v'",
 					gotIntAddr.Addresses, tt.internalAddress.Addresses)
 			}
 		})

--- a/integration/fixtures.go
+++ b/integration/fixtures.go
@@ -3,36 +3,41 @@ package integration
 import pb "github.com/ledgerhq/bitcoin-keychain-svc/pb/keychain"
 
 type Fixture struct {
-	Descriptor string
-	XPub       string
-	Network    pb.BitcoinNetwork
-	Scheme     pb.KeychainInfo_Scheme
+	ExternalDescriptor string
+	InternalDescriptor string
+	ExtendedPublicKey  string
+	Network            pb.BitcoinNetwork
+	Scheme             pb.Scheme
 }
 
 var BitcoinMainnetP2PKH = Fixture{
-	Descriptor: "pkh(xpub6DCi5iJ57ZPd5qPzvTm5hUt6X23TJdh9H4NjNsNbt7t7UuTMJfawQWsdWRFhfLwkiMkB1rQ4ZJWLB9YBnzR7kbs9N8b2PsKZgKUHQm1X4or)",
-	XPub:       "xpub6DCi5iJ57ZPd5qPzvTm5hUt6X23TJdh9H4NjNsNbt7t7UuTMJfawQWsdWRFhfLwkiMkB1rQ4ZJWLB9YBnzR7kbs9N8b2PsKZgKUHQm1X4or",
-	Network:    pb.BitcoinNetwork_BITCOIN_NETWORK_MAINNET,
-	Scheme:     pb.KeychainInfo_SCHEME_BIP44,
+	ExternalDescriptor: "pkh(xpub6DCi5iJ57ZPd5qPzvTm5hUt6X23TJdh9H4NjNsNbt7t7UuTMJfawQWsdWRFhfLwkiMkB1rQ4ZJWLB9YBnzR7kbs9N8b2PsKZgKUHQm1X4or/0/*)",
+	InternalDescriptor: "pkh(xpub6DCi5iJ57ZPd5qPzvTm5hUt6X23TJdh9H4NjNsNbt7t7UuTMJfawQWsdWRFhfLwkiMkB1rQ4ZJWLB9YBnzR7kbs9N8b2PsKZgKUHQm1X4or/1/*)",
+	ExtendedPublicKey:  "xpub6DCi5iJ57ZPd5qPzvTm5hUt6X23TJdh9H4NjNsNbt7t7UuTMJfawQWsdWRFhfLwkiMkB1rQ4ZJWLB9YBnzR7kbs9N8b2PsKZgKUHQm1X4or",
+	Network:            pb.BitcoinNetwork_BITCOIN_NETWORK_MAINNET,
+	Scheme:             pb.Scheme_SCHEME_BIP44,
 }
 
 var BitcoinTestnet3P2PKH = Fixture{
-	Descriptor: "pkh(tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba)",
-	XPub:       "tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba",
-	Network:    pb.BitcoinNetwork_BITCOIN_NETWORK_TESTNET3,
-	Scheme:     pb.KeychainInfo_SCHEME_BIP44,
+	ExternalDescriptor: "pkh(tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba/0/*)",
+	InternalDescriptor: "pkh(tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba/1/*)",
+	ExtendedPublicKey:  "tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba",
+	Network:            pb.BitcoinNetwork_BITCOIN_NETWORK_TESTNET3,
+	Scheme:             pb.Scheme_SCHEME_BIP44,
 }
 
 var BitcoinTestnet3P2SHP2WPKH = Fixture{
-	Descriptor: "sh(wpkh(tpubDCcvqEHx7prGddpWTfEviiew5YLMrrKy4oJbt14teJZenSi6AYMAs2SNXwYXFzkrNYwECSmobwxESxMCrpfqw4gsUt88bcr8iMrJmbb8P2q))",
-	XPub:       "tpubDCcvqEHx7prGddpWTfEviiew5YLMrrKy4oJbt14teJZenSi6AYMAs2SNXwYXFzkrNYwECSmobwxESxMCrpfqw4gsUt88bcr8iMrJmbb8P2q",
-	Network:    pb.BitcoinNetwork_BITCOIN_NETWORK_TESTNET3,
-	Scheme:     pb.KeychainInfo_SCHEME_BIP49,
+	ExternalDescriptor: "sh(wpkh(tpubDCcvqEHx7prGddpWTfEviiew5YLMrrKy4oJbt14teJZenSi6AYMAs2SNXwYXFzkrNYwECSmobwxESxMCrpfqw4gsUt88bcr8iMrJmbb8P2q/0/*))",
+	InternalDescriptor: "sh(wpkh(tpubDCcvqEHx7prGddpWTfEviiew5YLMrrKy4oJbt14teJZenSi6AYMAs2SNXwYXFzkrNYwECSmobwxESxMCrpfqw4gsUt88bcr8iMrJmbb8P2q/1/*))",
+	ExtendedPublicKey:  "tpubDCcvqEHx7prGddpWTfEviiew5YLMrrKy4oJbt14teJZenSi6AYMAs2SNXwYXFzkrNYwECSmobwxESxMCrpfqw4gsUt88bcr8iMrJmbb8P2q",
+	Network:            pb.BitcoinNetwork_BITCOIN_NETWORK_TESTNET3,
+	Scheme:             pb.Scheme_SCHEME_BIP49,
 }
 
 var BitcoinMainnetP2WPKH = Fixture{
-	Descriptor: "wpkh(xpub6CMeLkY9TzXyLYXPWMXB5LWtprVABb6HwPEPXnEgESMNrSUBsvhXNsA7zKS1ZRKhUyQG4HjZysEP8v7gDNU4J6PvN5yLx4meEm3mpEapLMN)",
-	XPub:       "xpub6CMeLkY9TzXyLYXPWMXB5LWtprVABb6HwPEPXnEgESMNrSUBsvhXNsA7zKS1ZRKhUyQG4HjZysEP8v7gDNU4J6PvN5yLx4meEm3mpEapLMN",
-	Network:    pb.BitcoinNetwork_BITCOIN_NETWORK_MAINNET,
-	Scheme:     pb.KeychainInfo_SCHEME_BIP84,
+	ExternalDescriptor: "wpkh(xpub6CMeLkY9TzXyLYXPWMXB5LWtprVABb6HwPEPXnEgESMNrSUBsvhXNsA7zKS1ZRKhUyQG4HjZysEP8v7gDNU4J6PvN5yLx4meEm3mpEapLMN/0/*)",
+	InternalDescriptor: "wpkh(xpub6CMeLkY9TzXyLYXPWMXB5LWtprVABb6HwPEPXnEgESMNrSUBsvhXNsA7zKS1ZRKhUyQG4HjZysEP8v7gDNU4J6PvN5yLx4meEm3mpEapLMN/1/*)",
+	ExtendedPublicKey:  "xpub6CMeLkY9TzXyLYXPWMXB5LWtprVABb6HwPEPXnEgESMNrSUBsvhXNsA7zKS1ZRKhUyQG4HjZysEP8v7gDNU4J6PvN5yLx4meEm3mpEapLMN",
+	Network:            pb.BitcoinNetwork_BITCOIN_NETWORK_MAINNET,
+	Scheme:             pb.Scheme_SCHEME_BIP84,
 }

--- a/integration/p2pkh_keychain_test.go
+++ b/integration/p2pkh_keychain_test.go
@@ -15,19 +15,22 @@ func TestP2PKHKeychainTest(t *testing.T) {
 	client, conn := keychainSvcClient(ctx)
 	defer conn.Close()
 
-	if _, err := client.CreateKeychain(ctx, &pb.CreateKeychainRequest{
-		AccountDescriptor: BitcoinMainnetP2PKH.Descriptor,
+	info, err := client.CreateKeychain(ctx, &pb.CreateKeychainRequest{
+		ExtendedPublicKey: BitcoinMainnetP2PKH.ExtendedPublicKey,
 		LookaheadSize:     20,
 		Network:           BitcoinMainnetP2PKH.Network,
-	}); err != nil {
+		Scheme:            BitcoinMainnetP2PKH.Scheme,
+	})
+
+	if err != nil {
 		t.Fatalf("failed to create keychain - error = %v", err)
 	}
 
 	gotObsAddrs, err := client.GetAllObservableAddresses(ctx, &pb.GetAllObservableAddressesRequest{
-		AccountDescriptor: BitcoinMainnetP2PKH.Descriptor,
-		Change:            pb.Change_CHANGE_EXTERNAL,
-		FromIndex:         0,
-		ToIndex:           10,
+		KeychainId: info.KeychainId,
+		Change:     pb.Change_CHANGE_EXTERNAL,
+		FromIndex:  0,
+		ToIndex:    10,
 	})
 	if err != nil {
 		t.Fatalf("failed to get addresses in observable range [1 10] - error = %v", err)
@@ -54,9 +57,9 @@ func TestP2PKHKeychainTest(t *testing.T) {
 
 	gotReceiveAddr, err := client.GetFreshAddresses(
 		ctx, &pb.GetFreshAddressesRequest{
-			AccountDescriptor: BitcoinMainnetP2PKH.Descriptor,
-			Change:            pb.Change_CHANGE_EXTERNAL,
-			BatchSize:         1,
+			KeychainId: info.KeychainId,
+			Change:     pb.Change_CHANGE_EXTERNAL,
+			BatchSize:  1,
 		})
 	if err != nil {
 		t.Fatalf("failed to get fresh external addr - error = %v", err)
@@ -69,17 +72,17 @@ func TestP2PKHKeychainTest(t *testing.T) {
 
 	if _, err := client.MarkAddressesAsUsed(
 		ctx, &pb.MarkAddressesAsUsedRequest{
-			AccountDescriptor: BitcoinMainnetP2PKH.Descriptor,
-			Addresses:         []string{"151krzHgfkNoH3XHBzEVi6tSn4db7pVjmR"},
+			KeychainId: info.KeychainId,
+			Addresses:  []string{"151krzHgfkNoH3XHBzEVi6tSn4db7pVjmR"},
 		}); err != nil {
 		t.Fatalf("MarkAddressesAsUsed() - error = %v", err)
 	}
 
 	gotNextReceiveAddr, err := client.GetFreshAddresses(
 		ctx, &pb.GetFreshAddressesRequest{
-			AccountDescriptor: BitcoinMainnetP2PKH.Descriptor,
-			Change:            pb.Change_CHANGE_EXTERNAL,
-			BatchSize:         1,
+			KeychainId: info.KeychainId,
+			Change:     pb.Change_CHANGE_EXTERNAL,
+			BatchSize:  1,
 		})
 	if err != nil {
 		t.Fatalf("failed to get fresh external addr - error = %v", err)

--- a/pb/keychain/service.proto
+++ b/pb/keychain/service.proto
@@ -7,16 +7,17 @@ option java_package = "co.ledger.protobuf.bitcoin";
 import "google/protobuf/empty.proto";
 
 service KeychainService {
-  // Create a new keychain by descriptor.
+  // Create a new keychain by extended public key.
   rpc CreateKeychain(CreateKeychainRequest) returns (KeychainInfo) {}
 
-  // Delete a keychain by descriptor.
+  // Delete a keychain by UUID.
   rpc DeleteKeychain(DeleteKeychainRequest) returns (google.protobuf.Empty) {}
 
-  // Get keychain metadata.
+  // Get keychain metadata by UUID.
   rpc GetKeychainInfo(GetKeychainInfoRequest) returns (KeychainInfo) {}
 
   // Mark a batch of addresses as used.
+  // NOTE: address being marked as used MUST be observable.
   rpc MarkAddressesAsUsed(MarkAddressesAsUsedRequest) returns (google.protobuf.Empty) {}
 
   // Get fresh addresses for a registered keychain and the provided Change.
@@ -48,59 +49,70 @@ enum Change {
   CHANGE_INTERNAL    = 2;  // internal chain
 }
 
+// Scheme defines the scheme on which a keychain entry is based.
+enum Scheme {
+  SCHEME_UNSPECIFIED = 0;  // fallback value if unrecognized / unspecified
+  SCHEME_BIP44       = 1;  // indicates that the keychain scheme is legacy.
+  SCHEME_BIP49       = 2;  // indicates that the keychain scheme is segwit.
+  SCHEME_BIP84       = 3;  // indicates that the keychain scheme is native segwit.
+}
+
 message CreateKeychainRequest {
-  string account_descriptor = 1;
-  uint32 lookahead_size = 2;
-  BitcoinNetwork network = 3;
+  string extended_public_key = 1;
+  Scheme scheme = 2;
+  uint32 lookahead_size = 3;
+  BitcoinNetwork network = 4;
 }
 
 message DeleteKeychainRequest {
-  string account_descriptor = 1;
+  // UUID representing the keychain
+  bytes keychain_id = 1;
 }
 
 message GetKeychainInfoRequest {
-  string account_descriptor = 1;
+  // UUID representing the keychain
+  bytes keychain_id = 1;
 }
 
 message KeychainInfo {
-  // Account descriptor of the keychain, at HD depth 3. MUST include the key
-  // origin information.
+  // UUID representing the keychain
+  bytes keychain_id = 1;
+
+  // External chain output descriptor of the keychain. It "describes" all
+  // external addresses that belong to the keychain.
   // Ref: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
-  string account_descriptor = 1;
+  string external_descriptor = 2;
+
+  // Internal chain output descriptor of the keychain. It "describes" all
+  // internal addresses that belong to the keychain.
+  string internal_descriptor = 3;
 
   // Extended public key serialized with standard HD version bytes.
-  string xpub = 2;
+  string extended_public_key = 4;
 
   // Extended public key serialized with SLIP-0132 HD version bytes.
   // Ref: https://github.com/satoshilabs/slips/blob/master/slip-0132.md
-  string slip32_extended_public_key = 3;
+  string slip32_extended_public_key = 5;
 
   // Numerical size of the lookahead zone.
-  uint32 lookahead_size = 4;
+  uint32 lookahead_size = 6;
 
-  // Scheme defines the scheme on which a keychain entry is based.
-  enum Scheme {
-    SCHEME_UNSPECIFIED = 0;  // fallback value if unrecognized / unspecified
-    SCHEME_BIP44       = 1;  // indicates that the keychain scheme is legacy.
-    SCHEME_BIP49       = 2;  // indicates that the keychain scheme is segwit.
-    SCHEME_BIP84       = 3;  // indicates that the keychain scheme is native segwit.
-  }
-  Scheme scheme = 5;
+  Scheme scheme = 7;
 
   // Network for which the keychain is defined.
   //
-  // Although the network information can be inferred from the account
-  // descriptor, it is often not enough to differentiate between Testnet3
-  // and Regtest networks, typically the case with the BIP84 scheme.
+  // Although the network information can be inferred from the extended public
+  // key, it is often not enough to differentiate between Testnet3 and Regtest
+  // networks, typically the case with the BIP84 scheme.
   //
   // This field is mostly useful for encoding addresses for a specific
   // network.
-  BitcoinNetwork network = 6;
+  BitcoinNetwork network = 8;
 }
 
 message MarkPathAsUsedRequest {
-  // Account descriptor of the keychain
-  string account_descriptor = 1;
+  // UUID representing the keychain
+  bytes keychain_id = 1;
 
   // Derivation path relative to BIP-32 account path-level.
   //
@@ -111,8 +123,8 @@ message MarkPathAsUsedRequest {
 }
 
 message GetFreshAddressesRequest {
-  // Account descriptor of the keychain
-  string account_descriptor = 1;
+  // UUID representing the keychain
+  bytes keychain_id = 1;
 
   // The chain on which the fresh addresses must be issued on.
   Change change = 2;
@@ -126,16 +138,16 @@ message GetFreshAddressesResponse {
 }
 
 message MarkAddressesAsUsedRequest {
-  // Account descriptor of the keychain
-  string account_descriptor = 1;
+  // UUID representing the keychain
+  bytes keychain_id = 1;
 
   // Addresses to be marked as used
   repeated string addresses = 2;
 }
 
 message GetAllObservableAddressesRequest {
-  // Account descriptor of the keychain
-  string account_descriptor = 1;
+  // UUID representing the keychain
+  bytes keychain_id = 1;
 
   // The chain on which the observable addresses must be returned.
   // If unspecified (CHANGE_UNSPECIFIED), return addresses observable on both

--- a/pkg/keystore/descriptor_test.go
+++ b/pkg/keystore/descriptor_test.go
@@ -9,80 +9,63 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestParseDescriptor(t *testing.T) {
+func TestMakeDescriptor(t *testing.T) {
 	tests := []struct {
-		name       string
-		descriptor string
-		want       DescriptorTokens
-		wantErr    error
+		name              string
+		extendedPublicKey string
+		scheme            Scheme
+		change            Change
+		want              string
+		wantErr           error
 	}{
 		{
-			name:       "legacy",
-			descriptor: "pkh(deadbeef)",
-			want: DescriptorTokens{
-				XPub:   "deadbeef",
-				Scheme: "BIP44",
-			},
+			name:              "legacy",
+			extendedPublicKey: "deadbeef",
+			scheme:            BIP44,
+			change:            External,
+			want:              "pkh(deadbeef/0/*)",
 		},
 		{
-			name:       "wrapped segwit",
-			descriptor: "sh(wpkh(deadbeef))",
-			want: DescriptorTokens{
-				XPub:   "deadbeef",
-				Scheme: "BIP49",
-			},
+			name:              "wrapped segwit",
+			extendedPublicKey: "deadbeef",
+			scheme:            BIP49,
+			change:            External,
+			want:              "sh(wpkh(deadbeef/0/*))",
 		},
 		{
-			name:       "native segwit",
-			descriptor: "wpkh(deadbeef)",
-			want: DescriptorTokens{
-				XPub:   "deadbeef",
-				Scheme: "BIP84",
-			},
+			name:              "native segwit",
+			extendedPublicKey: "deadbeef",
+			scheme:            BIP84,
+			change:            External,
+			want:              "wpkh(deadbeef/0/*)",
 		},
 		{
-			name:       "verbose wrapped segwit",
-			descriptor: "sh(wpkh([d34db33f/44'/0'/0']deadbeef/1/*))",
-			want: DescriptorTokens{
-				XPub:   "deadbeef",
-				Scheme: "BIP49",
-			},
-		},
-		{
-			name:       "invalid scheme",
-			descriptor: "abcd(deadbeef)",
-			wantErr:    ErrUnrecognizedScheme,
-		},
-		{
-			name:       "invalid descriptor",
-			descriptor: "wpkh(deadbeef",
-			wantErr:    ErrInvalidDescriptor,
-		},
-		{
-			name:       "empty descriptor",
-			descriptor: "wpkh()",
-			wantErr:    ErrInvalidDescriptor,
+			name:              "native segwit",
+			extendedPublicKey: "deadbeef",
+			scheme:            BIP84,
+			change:            Internal,
+			want:              "wpkh(deadbeef/1/*)",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseDescriptor(tt.descriptor)
+			got, err := MakeDescriptor(tt.extendedPublicKey, tt.change, tt.scheme)
 			if err != nil && tt.wantErr == nil {
-				t.Fatalf("ParseDescriptor() unexpected error: %v", err)
+				t.Fatalf("MakeDescriptor() unexpected error: %v", err)
 			}
 
 			if err == nil && tt.wantErr != nil {
-				t.Fatalf("ParseDescriptor() got no error, want '%v'",
+				t.Fatalf("MakeDescriptor() got no error, want '%v'",
 					tt.wantErr)
 			}
 
 			if err != nil && tt.wantErr != errors.Cause(err) {
-				t.Fatalf("ParseDescriptor() got error = %v, want = %v",
+				t.Fatalf("MakeDescriptor() got error = %v, want = %v",
 					err, tt.wantErr)
 			}
 
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ParseDescriptor() got = %v, want = %v", got, tt.want)
+				t.Errorf("MakeDescriptor() got = %v, want = %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/keystore/errors.go
+++ b/pkg/keystore/errors.go
@@ -3,10 +3,6 @@ package keystore
 import "github.com/pkg/errors"
 
 var (
-	// ErrInvalidDescriptor indicates that a descriptor string does not
-	// have the expected structure/format.
-	ErrInvalidDescriptor = errors.New("invalid descriptor")
-
 	// ErrUnrecognizedScheme indicates that the parsed scheme of a descriptor
 	// is invalid or missing.
 	ErrUnrecognizedScheme = errors.New("unrecognized scheme")
@@ -19,9 +15,9 @@ var (
 	// non-standard, and cannot be handled properly.
 	ErrUnrecognizedNetwork = errors.New("unrecognized network")
 
-	// ErrDescriptorNotFound indicates an attempt to get a descriptor from a
+	// ErrKeychainNotFound indicates an attempt to get a keychain by ID from a
 	// keystore that has not been registered.
-	ErrDescriptorNotFound = errors.New("descriptor not found")
+	ErrKeychainNotFound = errors.New("keychain not found")
 
 	// ErrAddressNotFound indicates that an address was not found in the
 	// address-to-derivations mapping in the keystore.

--- a/pkg/keystore/memory.go
+++ b/pkg/keystore/memory.go
@@ -1,6 +1,7 @@
 package keystore
 
 import (
+	"github.com/google/uuid"
 	"github.com/ledgerhq/bitcoin-keychain-svc/pb/bitcoin"
 	"github.com/pkg/errors"
 )
@@ -25,56 +26,69 @@ func NewInMemoryKeystore() Keystore {
 }
 
 // Get returns a previously stored keychain information based on the provided
-// descriptor string.
+// keychain UUID.
 //
-// Returns an error if the descriptor is missing in the keystore.
-func (s *InMemoryKeystore) Get(descriptor string) (KeychainInfo, error) {
-	document, ok := s.db[descriptor]
+// Returns an error if the keychain UUID is missing in the keystore.
+func (s *InMemoryKeystore) Get(id uuid.UUID) (KeychainInfo, error) {
+	document, ok := s.db[id]
 	if !ok {
-		return KeychainInfo{}, ErrDescriptorNotFound
+		return KeychainInfo{}, ErrKeychainNotFound
 	}
 
 	return document.Main, nil
 }
 
-// Create parses a descriptor string and populars the in-memory keystore with
-// the corresponding keychain information.
+// Create parses a populates the in-memory keystore with the corresponding
+// keychain information, based on the provided extended public key, Scheme,
+// and Network information.
 //
 // Only initial state is populated, so no addresses will be inserted into the
 // keystore by this method.
-func (s *InMemoryKeystore) Create(descriptor string, net Network) (KeychainInfo, error) {
-	tokens, err := ParseDescriptor(descriptor)
+func (s *InMemoryKeystore) Create(
+	extendedPublicKey string, scheme Scheme, net Network,
+) (KeychainInfo, error) {
+	internalDescriptor, err := MakeDescriptor(extendedPublicKey, Internal, scheme)
 	if err != nil {
-		return KeychainInfo{}, errors.Wrapf(
-			err, "failed to parse descriptor %v", descriptor)
+		return KeychainInfo{}, errors.Wrapf(err,
+			"failed to make internal descriptor, xkey = %v", extendedPublicKey)
 	}
 
-	externalChild, err := childKDF(s.client, tokens.XPub, 0)
+	externalDescriptor, err := MakeDescriptor(extendedPublicKey, External, scheme)
 	if err != nil {
-		return KeychainInfo{}, errors.Wrapf(
-			err, "failed to derive xpub %v at index %v", tokens.XPub, 0)
+		return KeychainInfo{}, errors.Wrapf(err,
+			"failed to make internal descriptor, xkey = %v", extendedPublicKey)
 	}
 
-	internalChild, err := childKDF(s.client, tokens.XPub, 1)
+	externalChild, err := childKDF(s.client, extendedPublicKey, 0)
 	if err != nil {
 		return KeychainInfo{}, errors.Wrapf(
-			err, "failed to derive xpub %v at index %v", tokens.XPub, 1)
+			err, "failed to derive xpub %v at index %v", extendedPublicKey, 0)
 	}
+
+	internalChild, err := childKDF(s.client, extendedPublicKey, 1)
+	if err != nil {
+		return KeychainInfo{}, errors.Wrapf(
+			err, "failed to derive xpub %v at index %v", extendedPublicKey, 1)
+	}
+
+	id := uuid.New()
 
 	keychainInfo := KeychainInfo{
-		Descriptor:                  descriptor,
-		XPub:                        tokens.XPub,
-		SLIP32ExtendedPublicKey:     tokens.XPub, // TODO: Convert XPub to SLIP-0132 form
+		ID:                          id,
+		InternalDescriptor:          internalDescriptor,
+		ExternalDescriptor:          externalDescriptor,
+		ExtendedPublicKey:           extendedPublicKey,
+		SLIP32ExtendedPublicKey:     extendedPublicKey, // TODO: Convert ExtendedPublicKey to SLIP-0132 form
 		ExternalXPub:                externalChild.ExtendedKey,
 		MaxConsecutiveExternalIndex: 0,
 		InternalXPub:                internalChild.ExtendedKey,
 		MaxConsecutiveInternalIndex: 0,
 		LookaheadSize:               lookaheadSize,
-		Scheme:                      tokens.Scheme,
+		Scheme:                      scheme,
 		Network:                     net,
 	}
 
-	s.db[descriptor] = &Meta{
+	s.db[id] = &Meta{
 		Main:        keychainInfo,
 		Derivations: map[DerivationPath]string{},
 		Addresses:   map[string]DerivationPath{},
@@ -84,13 +98,13 @@ func (s *InMemoryKeystore) Create(descriptor string, net Network) (KeychainInfo,
 }
 
 // GetFreshAddress retrieves an unused address from the in-memory keystore at a
-// given Change index, for the keychain corresponding to the provided
-// descriptor.
+// given Change index, for the keychain corresponding to the provided keychain
+// ID.
 //
 // See GetFreshAddresses for getting fresh addresses in bulk, and for further
 // details.
-func (s InMemoryKeystore) GetFreshAddress(descriptor string, change Change) (string, error) {
-	addrs, err := s.GetFreshAddresses(descriptor, change, 1)
+func (s InMemoryKeystore) GetFreshAddress(id uuid.UUID, change Change) (string, error) {
+	addrs, err := s.GetFreshAddresses(id, change, 1)
 	if err != nil {
 		return "", err
 	}
@@ -104,13 +118,13 @@ func (s InMemoryKeystore) GetFreshAddress(descriptor string, change Change) (str
 // method also detects gaps in used addresses and includes it in fresh address
 // list.
 func (s InMemoryKeystore) GetFreshAddresses(
-	descriptor string, change Change, size uint32,
+	id uuid.UUID, change Change, size uint32,
 ) ([]string, error) {
 	addrs := []string{}
 
-	k, ok := s.db[descriptor]
+	k, ok := s.db[id]
 	if !ok {
-		return addrs, ErrDescriptorNotFound
+		return addrs, ErrKeychainNotFound
 	}
 
 	maxConsecutiveIndex, err := k.MaxConsecutiveIndex(change)
@@ -152,11 +166,11 @@ func (s InMemoryKeystore) GetFreshAddresses(
 // detected and saved in the keystore. For this we rely on two main fields:
 //   MaxConsecutiveIndex   -> the largest consecutive index without any gaps
 //   NonConsecutiveIndexes -> list of used indexes that introduced gaps
-func (s *InMemoryKeystore) MarkPathAsUsed(descriptor string, path DerivationPath) error {
-	// Get keychain by descriptor
-	k, ok := s.db[descriptor]
+func (s *InMemoryKeystore) MarkPathAsUsed(id uuid.UUID, path DerivationPath) error {
+	// Get keychain by ID
+	k, ok := s.db[id]
 	if !ok {
-		return ErrDescriptorNotFound
+		return ErrKeychainNotFound
 	}
 
 	change := path.ChangeIndex()
@@ -241,11 +255,11 @@ func (s *InMemoryKeystore) MarkPathAsUsed(descriptor string, path DerivationPath
 }
 
 func (s *InMemoryKeystore) GetAllObservableAddresses(
-	descriptor string, change Change, fromIndex uint32, toIndex uint32,
+	id uuid.UUID, change Change, fromIndex uint32, toIndex uint32,
 ) ([]string, error) {
-	k, ok := s.db[descriptor]
+	k, ok := s.db[id]
 	if !ok {
-		return nil, ErrDescriptorNotFound
+		return nil, ErrKeychainNotFound
 	}
 
 	maxObservableIndex, err := k.MaxObservableIndex(change)
@@ -277,10 +291,10 @@ func (s *InMemoryKeystore) GetAllObservableAddresses(
 
 // GetDerivationPath reads the address-to-derivations mapping in the keystore,
 // and returns the DerivationPath corresponding to the specified address.
-func (s InMemoryKeystore) GetDerivationPath(descriptor string, address string) (DerivationPath, error) {
-	k, ok := s.db[descriptor]
+func (s InMemoryKeystore) GetDerivationPath(id uuid.UUID, address string) (DerivationPath, error) {
+	k, ok := s.db[id]
 	if !ok {
-		return DerivationPath{}, ErrDescriptorNotFound
+		return DerivationPath{}, ErrKeychainNotFound
 	}
 
 	path, ok := k.Addresses[address]
@@ -294,11 +308,11 @@ func (s InMemoryKeystore) GetDerivationPath(descriptor string, address string) (
 // MarkAddressAsUsed is a helper to directly mark an address as used. It
 // internally fetches the derivation path of the address from the keystore,
 // and then marks this DerivationPath value as used.
-func (s *InMemoryKeystore) MarkAddressAsUsed(descriptor string, address string) error {
-	path, err := s.GetDerivationPath(descriptor, address)
+func (s *InMemoryKeystore) MarkAddressAsUsed(id uuid.UUID, address string) error {
+	path, err := s.GetDerivationPath(id, address)
 	if err != nil {
 		return err
 	}
 
-	return s.MarkPathAsUsed(descriptor, path)
+	return s.MarkPathAsUsed(id, path)
 }


### PR DESCRIPTION
### What is this about?

Having an account-level descriptor like `wpkh(xpub1234)` is semantically wrong. [Descriptors](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md) should always describe outputs (addresses or scripts), hence an account would be represented as a set of two descriptors, as opposed to just one:

* internal chain => `wpkh(xpub1234/1/*)`
* external chain => `wpkh(xpub1234/0/*)`

Keychains are now registered using an extended public key, derivation scheme, and network information. The keychain identifier based on account-level descriptors was also modified to use random UUIDs.

Note that the keychain service will be the only component in the entire Lama suite to know about account xpubs. The Lama API will therefore have to retrieve this information directly from the keychain.

### Cute picture of animal

![](https://media1.tenor.com/images/92e0daae06bae6b22ce10da135be7658/tenor.gif?itemid=8595397)