### PR TITLE
Return AddressInfo message in GetAllObservableAddresses response

### DIFF
--- a/grpc/adapters.go
+++ b/grpc/adapters.go
@@ -124,3 +124,24 @@ func Scheme(scheme pb.Scheme) (keystore.Scheme, error) {
 		return "", ErrUnrecognizedScheme
 	}
 }
+
+// AddressInfoProto is an adapter function to convert a keystore.AddressInfo
+// to a pb.AddressInfo object.
+func AddressInfoProto(info keystore.AddressInfo) (*pb.AddressInfo, error) {
+	var change pb.Change
+
+	switch info.Change {
+	case keystore.External:
+		change = pb.Change_CHANGE_EXTERNAL
+	case keystore.Internal:
+		change = pb.Change_CHANGE_INTERNAL
+	default:
+		return nil, errors.Wrap(ErrUnrecognizedChange, fmt.Sprint(change))
+	}
+
+	return &pb.AddressInfo{
+		Address:    info.Address,
+		Derivation: info.Derivation.ToSlice(),
+		Change:     change,
+	}, nil
+}

--- a/grpc/keychain.go
+++ b/grpc/keychain.go
@@ -124,7 +124,7 @@ func (c Controller) GetAllObservableAddresses(
 		to = request.ToIndex
 	}
 
-	var addrs []string
+	var addrs []keystore.AddressInfo
 
 	for _, change := range changeList {
 		changeAddrs, err := c.store.GetAllObservableAddresses(
@@ -136,7 +136,18 @@ func (c Controller) GetAllObservableAddresses(
 		addrs = append(addrs, changeAddrs...)
 	}
 
-	return &pb.GetAllObservableAddressesResponse{Addresses: addrs}, nil
+	var addrInfoList []*pb.AddressInfo
+
+	for _, addrInfo := range addrs {
+		addrInfo, err := AddressInfoProto(addrInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		addrInfoList = append(addrInfoList, addrInfo)
+	}
+
+	return &pb.GetAllObservableAddressesResponse{Addresses: addrInfoList}, nil
 }
 
 // NewKeychainController returns a new instance of a Controller struct that

--- a/integration/p2pkh_keychain_test.go
+++ b/integration/p2pkh_keychain_test.go
@@ -36,18 +36,62 @@ func TestP2PKHKeychainTest(t *testing.T) {
 		t.Fatalf("failed to get addresses in observable range [1 10] - error = %v", err)
 	}
 
-	wantObsAddrs := &pb.GetAllObservableAddressesResponse{Addresses: []string{
-		"151krzHgfkNoH3XHBzEVi6tSn4db7pVjmR",
-		"18tMkbibtxJPQoTPUv8s3mSXqYzEsrbeRb",
-		"1GJr9FHZ1pbR4hjhX24M4L1BDUd2QogYYA",
-		"1KZB7aFfuZE2skJQPHH56VhSxUpUBjouwQ",
-		"1FyjDvDFcXLMmhMWD6u8bFovLgkhZabhTQ",
-		"1NGp18iPyWfSZz4AWnwT6HptDdVJfTjxnF",
-		"1L36ug5kWFLbMysfkAexh9LeicyMAteuEg",
-		"169V9snkmcdzpEDhRyLMnEuhLKyWdjzhfd",
-		"14K3JxsLwhpLiECaoJMsZYyk9peYP1Gtty",
-		"1GEix38AknUMWH8DYSn43HqodoB7RjyBAJ",
-		"1918hHSQNsNMRkDCUMy7DUmJ8GJzwfRkUV",
+	wantObsAddrs := &pb.GetAllObservableAddressesResponse{Addresses: []*pb.AddressInfo{
+		&pb.AddressInfo{
+			Address:    "151krzHgfkNoH3XHBzEVi6tSn4db7pVjmR",
+			Derivation: []uint32{0, 0},
+			Change:     pb.Change_CHANGE_EXTERNAL,
+		},
+		&pb.AddressInfo{
+			Address:    "18tMkbibtxJPQoTPUv8s3mSXqYzEsrbeRb",
+			Derivation: []uint32{0, 1},
+			Change:     pb.Change_CHANGE_EXTERNAL,
+		},
+		&pb.AddressInfo{
+			Address:    "1GJr9FHZ1pbR4hjhX24M4L1BDUd2QogYYA",
+			Derivation: []uint32{0, 2},
+			Change:     pb.Change_CHANGE_EXTERNAL,
+		},
+		&pb.AddressInfo{
+			Address:    "1KZB7aFfuZE2skJQPHH56VhSxUpUBjouwQ",
+			Derivation: []uint32{0, 3},
+			Change:     pb.Change_CHANGE_EXTERNAL,
+		},
+		&pb.AddressInfo{
+			Address:    "1FyjDvDFcXLMmhMWD6u8bFovLgkhZabhTQ",
+			Derivation: []uint32{0, 4},
+			Change:     pb.Change_CHANGE_EXTERNAL,
+		},
+		&pb.AddressInfo{
+			Address:    "1NGp18iPyWfSZz4AWnwT6HptDdVJfTjxnF",
+			Derivation: []uint32{0, 5},
+			Change:     pb.Change_CHANGE_EXTERNAL,
+		},
+		&pb.AddressInfo{
+			Address:    "1L36ug5kWFLbMysfkAexh9LeicyMAteuEg",
+			Derivation: []uint32{0, 6},
+			Change:     pb.Change_CHANGE_EXTERNAL,
+		},
+		&pb.AddressInfo{
+			Address:    "169V9snkmcdzpEDhRyLMnEuhLKyWdjzhfd",
+			Derivation: []uint32{0, 7},
+			Change:     pb.Change_CHANGE_EXTERNAL,
+		},
+		&pb.AddressInfo{
+			Address:    "14K3JxsLwhpLiECaoJMsZYyk9peYP1Gtty",
+			Derivation: []uint32{0, 8},
+			Change:     pb.Change_CHANGE_EXTERNAL,
+		},
+		&pb.AddressInfo{
+			Address:    "1GEix38AknUMWH8DYSn43HqodoB7RjyBAJ",
+			Derivation: []uint32{0, 9},
+			Change:     pb.Change_CHANGE_EXTERNAL,
+		},
+		&pb.AddressInfo{
+			Address:    "1918hHSQNsNMRkDCUMy7DUmJ8GJzwfRkUV",
+			Derivation: []uint32{0, 10},
+			Change:     pb.Change_CHANGE_EXTERNAL,
+		},
 	}}
 
 	if !proto.Equal(gotObsAddrs, wantObsAddrs) {

--- a/pb/keychain/service.proto
+++ b/pb/keychain/service.proto
@@ -57,6 +57,12 @@ enum Scheme {
   SCHEME_BIP84       = 3;  // indicates that the keychain scheme is native segwit.
 }
 
+message AddressInfo {
+  string address = 1;
+  repeated uint32 derivation = 2;
+  Change change = 3;
+}
+
 message CreateKeychainRequest {
   string extended_public_key = 1;
   Scheme scheme = 2;
@@ -163,5 +169,5 @@ message GetAllObservableAddressesRequest {
 }
 
 message GetAllObservableAddressesResponse {
-  repeated string addresses = 1;
+  repeated AddressInfo addresses = 1;
 }

--- a/pkg/keystore/bip32.go
+++ b/pkg/keystore/bip32.go
@@ -36,6 +36,12 @@ func (path DerivationPath) AddressIndex() uint32 {
 	return path[1]
 }
 
+// ToSlice returns the raw derivation path as a uint32 slice. The derivation
+// is relative to the BIP-32 account-level.
+func (path DerivationPath) ToSlice() []uint32 {
+	return []uint32{path[0], path[1]}
+}
+
 // Change is an enum type to indicate whether an address belongs to the
 // external chain (receive) or the internal chain (change).
 //

--- a/pkg/keystore/memory.go
+++ b/pkg/keystore/memory.go
@@ -256,7 +256,7 @@ func (s *InMemoryKeystore) MarkPathAsUsed(id uuid.UUID, path DerivationPath) err
 
 func (s *InMemoryKeystore) GetAllObservableAddresses(
 	id uuid.UUID, change Change, fromIndex uint32, toIndex uint32,
-) ([]string, error) {
+) ([]AddressInfo, error) {
 	k, ok := s.db[id]
 	if !ok {
 		return nil, ErrKeychainNotFound
@@ -275,15 +275,23 @@ func (s *InMemoryKeystore) GetAllObservableAddresses(
 		result = append(result, fromIndex+i)
 	}
 
-	addrs := make([]string, 0, len(result))
+	addrs := make([]AddressInfo, 0, len(result))
 
 	for _, i := range result {
-		addr, err := deriveAddress(s.client, k, DerivationPath{uint32(change), i})
+		path := DerivationPath{uint32(change), i}
+
+		addr, err := deriveAddress(s.client, k, path)
 		if err != nil {
 			return nil, err
 		}
 
-		addrs = append(addrs, addr)
+		addrInfo := AddressInfo{
+			Address:    addr,
+			Derivation: path,
+			Change:     change,
+		}
+
+		addrs = append(addrs, addrInfo)
 	}
 
 	return addrs, nil

--- a/pkg/keystore/store.go
+++ b/pkg/keystore/store.go
@@ -19,7 +19,7 @@ type Keystore interface {
 	MarkPathAsUsed(id uuid.UUID, path DerivationPath) error
 	MarkAddressAsUsed(id uuid.UUID, address string) error
 	GetAllObservableAddresses(id uuid.UUID, change Change,
-		fromIndex uint32, toIndex uint32) ([]string, error)
+		fromIndex uint32, toIndex uint32) ([]AddressInfo, error)
 	GetDerivationPath(id uuid.UUID, address string) (DerivationPath, error)
 }
 
@@ -85,6 +85,14 @@ type Meta struct {
 	Main        KeychainInfo              `json:"main"`
 	Derivations map[DerivationPath]string `json:"derivations"` // public key at HD tree depth 5
 	Addresses   map[string]DerivationPath `json:"addresses"`   // derivation path at HD tree depth 5
+}
+
+// AddressInfo encapsulates an address along with useful information associated
+// to the address.
+type AddressInfo struct {
+	Address    string
+	Derivation DerivationPath
+	Change     Change
 }
 
 // ChangeXPub returns the ExtendedPublicKey of the keychain for the specified Change


### PR DESCRIPTION
### What is this about?

The RPC method `GetAllObservableAddresses` now returns a slice of `AddressInfo` messages instead of `string` addresses. This is to prevent performing additional calls to the keychain to get more information about an observable address.

### Cute picture of animal

![](https://media.tenor.com/images/1d7c513d4b87f5c5dc3dc4600603fffd/tenor.gif)